### PR TITLE
fix: make the completion text color grey again

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -102,13 +102,13 @@
   .ais-SearchBox-input,
   .ais-SearchBox-completion {
     background: none;
-    color: inherit;
     height: 100%;
     padding: 0 48px;
     position: absolute;
     width: 100%;
   }
   .ais-SearchBox-input {
+    color: inherit;
     &::placeholder {
       color: #21243d;
       opacity: 1; // Firefox


### PR DESCRIPTION
This fixes a style move which made the completion text inherit the parent color after having been set to the right text color.