### PR TITLE
feat(list): design items hover state

### DIFF
--- a/src/components/ColorList.scss
+++ b/src/components/ColorList.scss
@@ -1,8 +1,12 @@
 .ais-ColorList {
   .ais-RefinementList-checkbox {
-    border: 0;
     border-radius: 50%;
     height: 24px;
     width: 24px;
+    &:hover,
+    &:focus {
+      border: 1px solid currentColor;
+      box-shadow: inset 0 0 0 1px #fff;
+    }
   }
 }

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -243,15 +243,17 @@ a[class^='ais-'] {
 .ais-RefinementList-checkbox {
   appearance: none;
   background-color: rgba(65, 66, 71, 0.08);
-  border: 0;
+  border: 1px solid rgba(65, 66, 71, 0.24);
   border-radius: 2px;
-  box-shadow: inset 0 0 1px 0 rgba(0, 0, 0, 0.5);
   color: var(--algolia-theme-primary);
   height: 1rem;
   margin: 0;
   margin-right: 1rem;
   position: relative;
   width: 1rem;
+  &:hover {
+    border: 1px solid currentColor;
+  }
   &:focus {
     box-shadow: 0 0 0 1px #fff, 0 0 2px 2px currentColor;
     outline: none;


### PR DESCRIPTION
This adds a design for the hover state on the refinement lists. Not having one is a bit confusing because we cannot anticipate if a click will trigger an action.

## Preview

![image](https://user-images.githubusercontent.com/6137112/79789761-fdf91700-834a-11ea-8c63-0656839159dc.png)

![image](https://user-images.githubusercontent.com/6137112/79789793-094c4280-834b-11ea-873f-7d84d0603618.png)
