### PR TITLE
feat(panel): hide panels when cannot refine

### DIFF
--- a/src/components/ColorList.js
+++ b/src/components/ColorList.js
@@ -4,6 +4,7 @@ import { connectRefinementList } from 'react-instantsearch-dom';
 import './ColorList.scss';
 import { FacetSearchBox } from './SearchBox/FacetSearchBox';
 import { PartialHighlight } from './PartialHighlight';
+import { PanelWrapper } from './Panel';
 
 export const ColorList = connectRefinementList((props) => {
   const [query, setQuery] = React.useState('');
@@ -18,100 +19,104 @@ export const ColorList = connectRefinementList((props) => {
   });
 
   return (
-    <div className="ais-ColorList ais-RefinementList">
-      {props.searchable && (
-        <div className="ais-RefinementList-searchBox">
-          <FacetSearchBox
-            inputRef={inputRef}
-            translations={{ placeholder: 'Search colors' }}
-            query={query}
-            onChange={(event) => {
-              const value = event.currentTarget.value;
-              setQuery(value);
-              props.searchForItems(value);
-            }}
-            onSubmit={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
+    <PanelWrapper {...props}>
+      <div className="ais-ColorList ais-RefinementList">
+        {props.searchable && (
+          <div className="ais-RefinementList-searchBox">
+            <FacetSearchBox
+              inputRef={inputRef}
+              translations={{ placeholder: 'Search colors' }}
+              query={query}
+              onChange={(event) => {
+                const value = event.currentTarget.value;
+                setQuery(value);
+                props.searchForItems(value);
+              }}
+              onSubmit={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
 
-              if (props.isFromSearch && props.items.length > 0) {
-                props.refine(props.items[0].value);
+                if (props.isFromSearch && props.items.length > 0) {
+                  props.refine(props.items[0].value);
+                  setQuery('');
+                }
+
+                if (inputRef.current) {
+                  inputRef.current.blur();
+                }
+              }}
+              onReset={() => {
                 setQuery('');
-              }
+                props.searchForItems('');
 
-              if (inputRef.current) {
-                inputRef.current.blur();
-              }
-            }}
-            onReset={() => {
-              setQuery('');
-              props.searchForItems('');
-
-              if (inputRef.current) {
-                inputRef.current.focus();
-              }
-            }}
-          />
-        </div>
-      )}
-
-      <div className="uni-RefinementList-ListContainer">
-        {props.isFromSearch && props.items.length === 0 && (
-          <p>No colors found.</p>
+                if (inputRef.current) {
+                  inputRef.current.focus();
+                }
+              }}
+            />
+          </div>
         )}
 
-        <ul className="ais-RefinementList-list">
-          {props.items.map((item) => {
-            const labelParts = item.label.split(';');
+        <div className="uni-RefinementList-ListContainer">
+          {props.isFromSearch && props.items.length === 0 && (
+            <p>No colors found.</p>
+          )}
 
-            if (labelParts.length !== 2) {
-              throw new Error(
-                `The Color widget expects colors with the following format: "Aluminium;#7f8084". Received "${item.label}".`
+          <ul className="ais-RefinementList-list">
+            {props.items.map((item) => {
+              const labelParts = item.label.split(';');
+
+              if (labelParts.length !== 2) {
+                throw new Error(
+                  `The Color widget expects colors with the following format: "Aluminium;#7f8084". Received "${item.label}".`
+                );
+              }
+
+              const [colorName, colorCode] = labelParts;
+
+              return (
+                <li
+                  key={item.label}
+                  className={[
+                    'ais-RefinementList-item',
+                    item.isRefined && 'ais-RefinementList-item--selected',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                >
+                  <label className="ais-RefinementList-label">
+                    <input
+                      className="ais-RefinementList-checkbox"
+                      style={{
+                        color: colorCode,
+                        backgroundColor: colorCode,
+                      }}
+                      type="checkbox"
+                      value={item.value}
+                      checked={item.isRefined}
+                      onChange={(event) => {
+                        event.preventDefault();
+                        props.refine(item.value);
+                        setQuery('');
+                      }}
+                    />
+                    <span className="ais-RefinementList-labelText">
+                      {props.isFromSearch ? (
+                        <PartialHighlight hit={item} attribute="label" />
+                      ) : (
+                        colorName
+                      )}
+                    </span>
+                    <span className="ais-RefinementList-count">
+                      {item.count}
+                    </span>
+                  </label>
+                </li>
               );
-            }
-
-            const [colorName, colorCode] = labelParts;
-
-            return (
-              <li
-                key={item.label}
-                className={[
-                  'ais-RefinementList-item',
-                  item.isRefined && 'ais-RefinementList-item--selected',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
-              >
-                <label className="ais-RefinementList-label">
-                  <input
-                    className="ais-RefinementList-checkbox"
-                    style={{
-                      color: colorCode,
-                      backgroundColor: colorCode,
-                    }}
-                    type="checkbox"
-                    value={item.value}
-                    checked={item.isRefined}
-                    onChange={(event) => {
-                      event.preventDefault();
-                      props.refine(item.value);
-                      setQuery('');
-                    }}
-                  />
-                  <span className="ais-RefinementList-labelText">
-                    {props.isFromSearch ? (
-                      <PartialHighlight hit={item} attribute="label" />
-                    ) : (
-                      colorName
-                    )}
-                  </span>
-                  <span className="ais-RefinementList-count">{item.count}</span>
-                </label>
-              </li>
-            );
-          })}
-        </ul>
+            })}
+          </ul>
+        </div>
       </div>
-    </div>
+    </PanelWrapper>
   );
 });

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -2,6 +2,18 @@ import React from 'react';
 
 import './Panel.scss';
 
+const PanelContext = React.createContext();
+
+function usePanelContext() {
+  const context = React.useContext(PanelContext);
+
+  if (!context) {
+    throw new Error('`usePanelContext` must be used within a Panel.');
+  }
+
+  return context;
+}
+
 export function Panel({
   isOpened: initialIsOpened = true,
   header,
@@ -10,47 +22,64 @@ export function Panel({
   ...rest
 }) {
   const [isOpened, setIsOpened] = React.useState(initialIsOpened);
+  const [canRefine, setCanRefine] = React.useState(true);
 
   return (
-    <div
-      className={[
-        'ais-Panel',
-        'ais-Panel--collapsible',
-        isOpened === false && 'ais-Panel--collapsed',
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      {...rest}
-    >
-      <div className="ais-Panel-header">
-        <button
-          className="ais-Panel-headerButton"
-          aria-expanded={isOpened}
-          onClick={() => setIsOpened((prevValue) => !prevValue)}
-        >
-          <div>{header}</div>
+    <PanelContext.Provider value={{ setCanRefine }}>
+      <div
+        className={[
+          'ais-Panel',
+          'ais-Panel--collapsible',
+          canRefine === false && 'ais-Panel-noRefinement',
+          isOpened === false && 'ais-Panel--collapsed',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        {...rest}
+      >
+        <div className="ais-Panel-header">
+          <button
+            className="ais-Panel-headerButton"
+            aria-expanded={isOpened}
+            onClick={() => setIsOpened((prevValue) => !prevValue)}
+          >
+            <div>{header}</div>
 
-          <div className="ais-Panel-collapseButton">
-            {isOpened ? (
-              <svg viewBox="0 0 13 13" width={13} height={13}>
-                <path fill="currentColor" d="M0 6h13v1H0z" fillRule="evenodd" />
-              </svg>
-            ) : (
-              <svg viewBox="0 0 13 13" width={13} height={13}>
-                <path
-                  fill="currentColor"
-                  d="M6 6V0h1v6h6v1H7v6H6V7H0V6h6z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            )}
-          </div>
-        </button>
+            <div className="ais-Panel-collapseButton">
+              {isOpened ? (
+                <svg viewBox="0 0 13 13" width={13} height={13}>
+                  <path
+                    fill="currentColor"
+                    d="M0 6h13v1H0z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              ) : (
+                <svg viewBox="0 0 13 13" width={13} height={13}>
+                  <path
+                    fill="currentColor"
+                    d="M6 6V0h1v6h6v1H7v6H6V7H0V6h6z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              )}
+            </div>
+          </button>
+        </div>
+
+        <div className="ais-Panel-body">{children}</div>
+
+        {footer && <div className="ais-Panel-footer">{footer}</div>}
       </div>
-
-      <div className="ais-Panel-body">{children}</div>
-
-      {footer && <div className="ais-Panel-footer">{footer}</div>}
-    </div>
+    </PanelContext.Provider>
   );
 }
+export const PanelWrapper = (props) => {
+  const { setCanRefine } = usePanelContext();
+
+  React.useEffect(() => {
+    setCanRefine(props.canRefine);
+  }, [setCanRefine, props.canRefine]);
+
+  return props.children;
+};

--- a/src/components/Panel.scss
+++ b/src/components/Panel.scss
@@ -18,3 +18,7 @@
     width: 100%;
   }
 }
+
+.ais-Panel-noRefinement {
+  display: none;
+}

--- a/src/components/SizeList.js
+++ b/src/components/SizeList.js
@@ -3,6 +3,7 @@ import { connectRefinementList } from 'react-instantsearch-dom';
 
 import { FacetSearchBox } from './SearchBox/FacetSearchBox';
 import { PartialHighlight } from './PartialHighlight';
+import { PanelWrapper } from './Panel';
 
 export const SizeList = connectRefinementList((props) => {
   const [query, setQuery] = React.useState('');
@@ -17,96 +18,100 @@ export const SizeList = connectRefinementList((props) => {
   });
 
   return (
-    <div className="ais-RefinementList">
-      {props.searchable && (
-        <div className="ais-RefinementList-searchBox">
-          <FacetSearchBox
-            inputRef={inputRef}
-            translations={{ placeholder: 'Search sizes' }}
-            query={query}
-            onChange={(event) => {
-              const value = event.currentTarget.value;
-              setQuery(value);
-              props.searchForItems(value);
-            }}
-            onSubmit={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
+    <PanelWrapper {...props}>
+      <div className="ais-RefinementList">
+        {props.searchable && (
+          <div className="ais-RefinementList-searchBox">
+            <FacetSearchBox
+              inputRef={inputRef}
+              translations={{ placeholder: 'Search sizes' }}
+              query={query}
+              onChange={(event) => {
+                const value = event.currentTarget.value;
+                setQuery(value);
+                props.searchForItems(value);
+              }}
+              onSubmit={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
 
-              if (props.isFromSearch && props.items.length > 0) {
-                props.refine(props.items[0].value);
+                if (props.isFromSearch && props.items.length > 0) {
+                  props.refine(props.items[0].value);
+                  setQuery('');
+                }
+
+                if (inputRef.current) {
+                  inputRef.current.blur();
+                }
+              }}
+              onReset={() => {
                 setQuery('');
-              }
+                props.searchForItems('');
 
-              if (inputRef.current) {
-                inputRef.current.blur();
-              }
-            }}
-            onReset={() => {
-              setQuery('');
-              props.searchForItems('');
-
-              if (inputRef.current) {
-                inputRef.current.focus();
-              }
-            }}
-          />
-        </div>
-      )}
-
-      <div className="uni-RefinementList-ListContainer">
-        {props.isFromSearch && props.items.length === 0 && (
-          <p>No sizes found.</p>
+                if (inputRef.current) {
+                  inputRef.current.focus();
+                }
+              }}
+            />
+          </div>
         )}
 
-        <ul className="ais-RefinementList-list">
-          {props.items.map((item) => {
-            const labelParts = item.label.split(';');
+        <div className="uni-RefinementList-ListContainer">
+          {props.isFromSearch && props.items.length === 0 && (
+            <p>No sizes found.</p>
+          )}
 
-            if (labelParts.length < 2) {
-              throw new Error(
-                `The Size widget expects sizes with the following format: "XL;6". Received "${item.label}".`
+          <ul className="ais-RefinementList-list">
+            {props.items.map((item) => {
+              const labelParts = item.label.split(';');
+
+              if (labelParts.length < 2) {
+                throw new Error(
+                  `The Size widget expects sizes with the following format: "XL;6". Received "${item.label}".`
+                );
+              }
+
+              const [sizeName] = labelParts;
+
+              return (
+                <li
+                  key={item.label}
+                  className={[
+                    'ais-RefinementList-item',
+                    item.isRefined && 'ais-RefinementList-item--selected',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                >
+                  <label className="ais-RefinementList-label">
+                    <input
+                      className="ais-RefinementList-checkbox"
+                      type="checkbox"
+                      value={item.value}
+                      checked={item.isRefined}
+                      onChange={(event) => {
+                        event.preventDefault();
+                        props.refine(item.value);
+                        setQuery('');
+                      }}
+                    />
+                    <span className="ais-RefinementList-labelText">
+                      {props.isFromSearch ? (
+                        <PartialHighlight hit={item} attribute="label" />
+                      ) : (
+                        sizeName
+                      )}
+                    </span>
+                    <span className="ais-RefinementList-count">
+                      {item.count}
+                    </span>
+                  </label>
+                </li>
               );
-            }
-
-            const [sizeName] = labelParts;
-
-            return (
-              <li
-                key={item.label}
-                className={[
-                  'ais-RefinementList-item',
-                  item.isRefined && 'ais-RefinementList-item--selected',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
-              >
-                <label className="ais-RefinementList-label">
-                  <input
-                    className="ais-RefinementList-checkbox"
-                    type="checkbox"
-                    value={item.value}
-                    checked={item.isRefined}
-                    onChange={(event) => {
-                      event.preventDefault();
-                      props.refine(item.value);
-                      setQuery('');
-                    }}
-                  />
-                  <span className="ais-RefinementList-labelText">
-                    {props.isFromSearch ? (
-                      <PartialHighlight hit={item} attribute="label" />
-                    ) : (
-                      sizeName
-                    )}
-                  </span>
-                  <span className="ais-RefinementList-count">{item.count}</span>
-                </label>
-              </li>
-            );
-          })}
-        </ul>
+            })}
+          </ul>
+        </div>
       </div>
-    </div>
+    </PanelWrapper>
   );
 });

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -4,56 +4,61 @@ import Rheostat from 'rheostat';
 
 import './Slider.scss';
 
-export const Slider = connectRange(
-  ({ min, max, currentRefinement, refine, transformValue = (x) => x }) => {
-    const [currentMin, setCurrentMin] = React.useState(null);
-    const [currentMax, setCurrentMax] = React.useState(null);
+import { PanelWrapper } from './Panel';
 
-    function computeMinValue(value) {
-      return Math.min(Math.max(value, min), max);
-    }
+export const Slider = connectRange((props) => {
+  const {
+    min,
+    max,
+    currentRefinement,
+    refine,
+    transformValue = (x) => x,
+  } = props;
+  const [currentMin, setCurrentMin] = React.useState(null);
+  const [currentMax, setCurrentMax] = React.useState(null);
 
-    function computeMaxValue(value) {
-      return Math.max(Math.min(value, max), min);
-    }
+  function computeMinValue(value) {
+    return Math.min(Math.max(value, min), max);
+  }
 
-    function onChange({ values }) {
-      if (
-        currentRefinement.min !== values[0] ||
-        currentRefinement.max !== values[1]
-      ) {
-        let computedMin = computeMinValue(values[0]);
-        let computedMax = computeMaxValue(values[1]);
+  function computeMaxValue(value) {
+    return Math.max(Math.min(value, max), min);
+  }
 
-        if (computedMin === computedMax && computedMin > min) {
-          computedMin -= 1;
-        } else if (computedMin === computedMax && computedMax < max) {
-          computedMax += 1;
-        }
+  function onChange({ values }) {
+    if (
+      currentRefinement.min !== values[0] ||
+      currentRefinement.max !== values[1]
+    ) {
+      let computedMin = computeMinValue(values[0]);
+      let computedMax = computeMaxValue(values[1]);
 
-        refine({
-          min: computedMin,
-          max: computedMax,
-        });
+      if (computedMin === computedMax && computedMin > min) {
+        computedMin -= 1;
+      } else if (computedMin === computedMax && computedMax < max) {
+        computedMax += 1;
       }
+
+      refine({
+        min: computedMin,
+        max: computedMax,
+      });
     }
+  }
 
-    function onValuesUpdated({ values }) {
-      setCurrentMin(computeMinValue(values[0]));
-      setCurrentMax(computeMaxValue(values[1]));
-    }
+  function onValuesUpdated({ values }) {
+    setCurrentMin(computeMinValue(values[0]));
+    setCurrentMax(computeMaxValue(values[1]));
+  }
 
-    // `min` and `max` values are passed as `undefined` on the first render.
-    React.useEffect(() => {
-      setCurrentMin(min);
-      setCurrentMax(max);
-    }, [min, max]);
+  // `min` and `max` values are passed as `undefined` on the first render.
+  React.useEffect(() => {
+    setCurrentMin(min);
+    setCurrentMax(max);
+  }, [min, max]);
 
-    if (min === max) {
-      return null;
-    }
-
-    return (
+  return (
+    <PanelWrapper {...props}>
       <div className="uni-Slider">
         <div className="uni-Slider-bar">
           <Rheostat
@@ -76,6 +81,6 @@ export const Slider = connectRange(
           </div>
         </div>
       </div>
-    );
-  }
-);
+    </PanelWrapper>
+  );
+});


### PR DESCRIPTION
This hides the custom widgets when they cannot be refined, via their `Panel`s.

## Description

This only works with custom widgets (`ColorList`, `SizeList`, `Slider`) because we cannot get the `canRefine` value of a React InstantSearch widget. Long term, I think all widgets will be custom anyway to better fit the e-commerce use case (stacked panel refinements, etc.).

## Changes

The changes that you see in the list components are only wrapping them with `PanelWrapper`.

## Preview

[See refinements →](https://deploy-preview-40--ecomm-unified-algolia.netlify.app/?query=aka&menu%5Bcategory%5D=beach%20bound) (sizes are not showing)

## Next steps

Later, we can think about using this `PanelContext` to collapse/uncollapse panels on user interactions.