### PR TITLE
fix(view): use grid layout for hits

### DIFF
--- a/src/components/Hit.js
+++ b/src/components/Hit.js
@@ -13,22 +13,24 @@ export function Hit({ hit, insights, view }) {
         })
       }
     >
-      <a href={`https://asos.com/${hit.url}`}>
+      <a href={`https://asos.com/${hit.url}`} className="uni-Hit-inner">
         <div className="uni-Hit-image">
           <img src={hit.image} alt={hit.description} />
         </div>
 
         <div className="uni-Hit-Body">
-          <header>
-            <h2>{[hit.brand, hit.gender].filter(Boolean).join(' · ')}</h2>
+          <header className="uni-Hit-header">
+            <h2 className="uni-Hit-category">
+              {[hit.brand, hit.gender].filter(Boolean).join(' · ')}
+            </h2>
 
-            <h1>
+            <h1 className="uni-Hit-title">
               <Highlight attribute="description" tagName="mark" hit={hit} />
             </h1>
           </header>
 
           {view === 'list' && (
-            <p>
+            <p className="uni-Hit-description">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit.
               Suspendisse placerat lectus non dui suscipit cursus. Ut interdum
               ac nisi eget egestas.

--- a/src/components/Hit.scss
+++ b/src/components/Hit.scss
@@ -2,46 +2,51 @@
   color: #21243d;
   font-size: 14px;
   line-height: 18px;
-  header {
-    display: grid;
-    grid-gap: 0.5rem;
-  }
-  h1 {
-    font-size: 14px;
-    letter-spacing: 0.025rem;
-  }
-  h2 {
-    color: #21243d;
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 1;
-    opacity: 0.7;
-    text-transform: uppercase;
-  }
-  a {
-    border: 1px solid #fff;
-    border-radius: 3px;
-    color: inherit;
-    display: grid;
-    grid-gap: 1rem;
-    padding: 1rem;
-    text-decoration: inherit;
-    &:hover,
-    &:focus {
-      border-color: #ddd;
-      box-shadow: 0 2px 6px rgba(200, 200, 200, 0.24);
-      h1 {
-        text-decoration: underline;
-      }
-      .ais-Highlight-highlighted,
-      .ais-Snippet-highlighted {
-        border-bottom: 0;
-      }
+}
+
+.uni-Hit-header {
+  display: grid;
+  grid-gap: 0.5rem;
+}
+
+.uni-Hit-title {
+  font-size: 14px;
+  letter-spacing: 0.025rem;
+}
+
+.uni-Hit-category {
+  color: #21243d;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  opacity: 0.7;
+  text-transform: uppercase;
+}
+
+.uni-Hit-inner {
+  border: 1px solid #fff;
+  border-radius: 3px;
+  color: inherit;
+  display: grid;
+  grid-gap: 1rem;
+  padding: 1rem;
+  text-decoration: inherit;
+  &:hover,
+  &:focus {
+    border-color: #ddd;
+    box-shadow: 0 2px 6px rgba(200, 200, 200, 0.24);
+    .uni-Hit-title {
+      text-decoration: underline;
+    }
+    .ais-Highlight-highlighted,
+    .ais-Snippet-highlighted {
+      border-bottom: 0;
     }
   }
-  p {
-    color: #777;
-  }
+}
+
+.uni-Hit-description {
+  color: #777;
 }
 
 .uni-Hit-image {
@@ -57,10 +62,8 @@
 }
 
 .uni-Hits--listView {
-  .uni-Hit {
-    a {
-      grid-template-columns: 100px 1fr;
-    }
+  .uni-Hit-inner {
+    grid-template-columns: 100px 1fr;
   }
   .uni-Hit-image {
     min-height: 130px;


### PR DESCRIPTION
This simplifies the CSS for the hits to use a grid.

This follows the principle of using grids for layouts. It forces the spacing constraints on the parents rather than on the children themselves, which is closer to the way you design too.

A nice side effect is that it's less error prone, as it fixes a `padding-top` that wasn't meant to be here in list view.