### PR TITLE
fix: wrap and space current refinements

### DIFF
--- a/src/components/CurrentRefinements.scss
+++ b/src/components/CurrentRefinements.scss
@@ -4,7 +4,7 @@
 
 .ais-CurrentRefinements-list {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 
 .ais-CurrentRefinements-item {
@@ -13,6 +13,7 @@
   border-radius: 3px;
   color: #fff;
   display: flex;
+  margin: 0.25rem 0;
   white-space: nowrap;
   &:not(:last-of-type) {
     margin-right: 0.5rem;

--- a/src/reset.scss
+++ b/src/reset.scss
@@ -19,7 +19,6 @@
   p,
   ul,
   ol,
-  li,
   figure,
   figcaption,
   blockquote,


### PR DESCRIPTION
This wraps current refinements so they don't overflow, and adds some space around them.

**Note:** a change to the reset was necessary, because it applies a rule that's too specific on many generic selectors. In a next iteration, we need to change that reset and instead manually reset on specific elements, otherwise it's going to cause issues and force us to use patterns we should avoid.