### PR TITLE
fix: visually rearrange alignments in refinement lists

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -347,7 +347,7 @@
 
 .uni-RefinementList-ListContainer {
   max-height: 300px;
-  overflow: scroll;
+  overflow-y: scroll;
 }
 
 /* Hits */

--- a/src/components/ColorList.scss
+++ b/src/components/ColorList.scss
@@ -9,4 +9,10 @@
       box-shadow: inset 0 0 0 1px #fff;
     }
   }
+  .ais-RefinementList-labelText {
+    margin-top: 3px;
+  }
+  .ais-RefinementList-count {
+    margin-top: 6px;
+  }
 }

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -235,9 +235,8 @@ a[class^='ais-'] {
 .ais-Menu-link,
 .ais-RatingMenu-link,
 .ais-RefinementList-label {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
-  white-space: nowrap;
 }
 
 .ais-RefinementList-checkbox {
@@ -246,9 +245,11 @@ a[class^='ais-'] {
   border: 1px solid rgba(65, 66, 71, 0.24);
   border-radius: 2px;
   color: var(--algolia-theme-primary);
+  flex-shrink: 0;
   height: 1rem;
   margin: 0;
   margin-right: 1rem;
+  margin-top: 1px;
   position: relative;
   width: 1rem;
   &:hover {
@@ -294,6 +295,11 @@ a[class^='ais-'] {
   letter-spacing: 1.1px;
   margin-left: 8px;
   padding: 0 4px;
+}
+
+.ais-RefinementList-count,
+.ais-Menu-count {
+  margin-top: 3px;
 }
 
 .ais-HierarchicalMenu-showMore,


### PR DESCRIPTION
This arranges a few issues on the refinement lists.

## The problem(s)

So far, the refinement lists overflew on both axis. Scrolling on the x-axis isn't awesome UX; if we can avoid it, we should. By only allowing to overflow on the y-axis, we also needed to make sure that long refinements wrap when they're longer than the allocated width.

If we allow wrapping, it also means we need to make sure that it looks good both with single-line and multi-line refinements. So far, long refinements crushed the checkbox, and resulted in an odd look because of the vertical center alignment.

## The solution(s)

Vertical center alignment works well for single-line refinements, not for multi-line ones. By aligning to the top, and manually centering children, we create the illusion of vertical centering for single-line refinements, and we grow from the top down when the refinement wraps into multiple lines.

## Before

![Capture d’écran 2020-04-21 à 14 07 12](https://user-images.githubusercontent.com/5370675/79864238-6bec1f80-83d9-11ea-9ecd-f798d9dc253f.png)

## After

![Capture d’écran 2020-04-21 à 13 58 21](https://user-images.githubusercontent.com/5370675/79864201-57a82280-83d9-11ea-96ee-bc52690803d0.png)

