### PR TITLE
fix: make global scroll vertical only

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -12,7 +12,7 @@
     Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   left: 0;
-  overflow: scroll;
+  overflow-y: scroll;
   position: fixed;
   right: 0;
   top: 0;


### PR DESCRIPTION
This makes the global scroll vertical only, to avoid generating an empty horizontal scrollbar gutter.