### PR TITLE
refactor: name React components

### DIFF
--- a/src/components/ColorList.js
+++ b/src/components/ColorList.js
@@ -6,7 +6,7 @@ import { FacetSearchBox } from './SearchBox/FacetSearchBox';
 import { PartialHighlight } from './PartialHighlight';
 import { PanelWrapper } from './Panel';
 
-export const ColorList = connectRefinementList((props) => {
+export const ColorList = connectRefinementList(function ColorList(props) {
   const [query, setQuery] = React.useState('');
   const inputRef = React.useRef(null);
 

--- a/src/components/CurrentRefinements.js
+++ b/src/components/CurrentRefinements.js
@@ -62,7 +62,7 @@ function getRefinement(refinement, config) {
 }
 
 export const CurrentRefinements = connectCurrentRefinements(
-  ({ items, refine }) => {
+  function CurrentRefinements({ items, refine }) {
     const { config } = useAppContext();
 
     const refinements = items.reduce((acc, current) => {

--- a/src/components/Hits.js
+++ b/src/components/Hits.js
@@ -3,7 +3,7 @@ import { connectHits, Pagination } from 'react-instantsearch-dom';
 
 import { useAppContext } from '../hooks';
 
-export const Hits = connectHits((props) => {
+export const Hits = connectHits(function Hits(props) {
   const { view } = useAppContext();
 
   return (

--- a/src/components/InfiniteHits.js
+++ b/src/components/InfiniteHits.js
@@ -3,7 +3,7 @@ import { connectInfiniteHits } from 'react-instantsearch-dom';
 
 import { useAppContext, useIntersectionObserver } from '../hooks';
 
-export const InfiniteHits = connectInfiniteHits((props) => {
+export const InfiniteHits = connectInfiniteHits(function InfiniteHits(props) {
   const { view } = useAppContext();
   const { setObservedNode } = useIntersectionObserver({
     callback: props.refineNext,

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -25,53 +25,51 @@ export function Panel({
   const [canRefine, setCanRefine] = React.useState(true);
 
   return (
-    <PanelContext.Provider value={{ setCanRefine }}>
-      <div
-        className={[
-          'ais-Panel',
-          'ais-Panel--collapsible',
-          canRefine === false && 'ais-Panel-noRefinement',
-          isOpened === false && 'ais-Panel--collapsed',
-        ]
-          .filter(Boolean)
-          .join(' ')}
-        {...rest}
-      >
-        <div className="ais-Panel-header">
-          <button
-            className="ais-Panel-headerButton"
-            aria-expanded={isOpened}
-            onClick={() => setIsOpened((prevValue) => !prevValue)}
-          >
-            <div>{header}</div>
+    <div
+      className={[
+        'ais-Panel',
+        'ais-Panel--collapsible',
+        canRefine === false && 'ais-Panel-noRefinement',
+        isOpened === false && 'ais-Panel--collapsed',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      {...rest}
+    >
+      <div className="ais-Panel-header">
+        <button
+          className="ais-Panel-headerButton"
+          aria-expanded={isOpened}
+          onClick={() => setIsOpened((prevValue) => !prevValue)}
+        >
+          <div>{header}</div>
 
-            <div className="ais-Panel-collapseButton">
-              {isOpened ? (
-                <svg viewBox="0 0 13 13" width={13} height={13}>
-                  <path
-                    fill="currentColor"
-                    d="M0 6h13v1H0z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              ) : (
-                <svg viewBox="0 0 13 13" width={13} height={13}>
-                  <path
-                    fill="currentColor"
-                    d="M6 6V0h1v6h6v1H7v6H6V7H0V6h6z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              )}
-            </div>
-          </button>
-        </div>
-
-        <div className="ais-Panel-body">{children}</div>
-
-        {footer && <div className="ais-Panel-footer">{footer}</div>}
+          <div className="ais-Panel-collapseButton">
+            {isOpened ? (
+              <svg viewBox="0 0 13 13" width={13} height={13}>
+                <path fill="currentColor" d="M0 6h13v1H0z" fillRule="evenodd" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 13 13" width={13} height={13}>
+                <path
+                  fill="currentColor"
+                  d="M6 6V0h1v6h6v1H7v6H6V7H0V6h6z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            )}
+          </div>
+        </button>
       </div>
-    </PanelContext.Provider>
+
+      <div className="ais-Panel-body">
+        <PanelContext.Provider value={{ setCanRefine }}>
+          {children}
+        </PanelContext.Provider>
+      </div>
+
+      {footer && <div className="ais-Panel-footer">{footer}</div>}
+    </div>
   );
 }
 export const PanelWrapper = (props) => {
@@ -79,7 +77,7 @@ export const PanelWrapper = (props) => {
 
   React.useEffect(() => {
     setCanRefine(props.canRefine);
-  }, [setCanRefine, props.canRefine]);
+  }, [setCanRefine, props.canRefine, props.isFromSearch]);
 
   return props.children;
 };

--- a/src/components/SearchBox/ConnectedPredictiveSearchBox.js
+++ b/src/components/SearchBox/ConnectedPredictiveSearchBox.js
@@ -9,58 +9,60 @@ import {
 import { ReverseHighlight } from '../ReverseHighlight';
 import { SearchBox } from './SearchBox';
 
-export const ConnectedPredictiveSearchBox = connectSearchBox((props) => {
-  const [currentSuggestion, setCurrentSuggestion] = React.useState(null);
+export const ConnectedPredictiveSearchBox = connectSearchBox(
+  function PredictiveSearchBox(props) {
+    const [currentSuggestion, setCurrentSuggestion] = React.useState(null);
 
-  return (
-    <>
-      <SearchBox
-        {...props}
-        completion={
-          props.currentRefinement &&
-          currentSuggestion &&
-          currentSuggestion !== props.currentRefinement
-            ? currentSuggestion
-            : null
-        }
-        onChange={(event) => {
-          setCurrentSuggestion(null);
-          props.refine(event.currentTarget.value);
-        }}
-        onKeyDown={(event) => {
-          // When the user hits the right arrow and is at the end of the
-          // input query, we validate the completion.
-          if (
-            event.key === 'Tab' ||
-            (event.key === 'ArrowRight' &&
-              event.target.selectionStart === props.currentRefinement.length)
-          ) {
-            event.preventDefault();
-            props.refine(currentSuggestion);
+    return (
+      <>
+        <SearchBox
+          {...props}
+          completion={
+            props.currentRefinement &&
+            currentSuggestion &&
+            currentSuggestion !== props.currentRefinement
+              ? currentSuggestion
+              : null
           }
-        }}
-        onSubmit={() => {}}
-        onReset={() => {
-          props.refine('');
-        }}
-      />
-
-      <Index indexName={props.suggestionsIndex.indexName}>
-        <Configure page={0} {...props.suggestionsIndex.searchParameters} />
-        <Suggestions
-          query={props.currentRefinement}
-          onSuggestion={(suggestion) => setCurrentSuggestion(suggestion)}
-          onClick={(value) => {
-            props.refine(value);
+          onChange={(event) => {
             setCurrentSuggestion(null);
+            props.refine(event.currentTarget.value);
+          }}
+          onKeyDown={(event) => {
+            // When the user hits the right arrow and is at the end of the
+            // input query, we validate the completion.
+            if (
+              event.key === 'Tab' ||
+              (event.key === 'ArrowRight' &&
+                event.target.selectionStart === props.currentRefinement.length)
+            ) {
+              event.preventDefault();
+              props.refine(currentSuggestion);
+            }
+          }}
+          onSubmit={() => {}}
+          onReset={() => {
+            props.refine('');
           }}
         />
-      </Index>
-    </>
-  );
-});
 
-const Suggestions = connectHits((props) => {
+        <Index indexName={props.suggestionsIndex.indexName}>
+          <Configure page={0} {...props.suggestionsIndex.searchParameters} />
+          <Suggestions
+            query={props.currentRefinement}
+            onSuggestion={(suggestion) => setCurrentSuggestion(suggestion)}
+            onClick={(value) => {
+              props.refine(value);
+              setCurrentSuggestion(null);
+            }}
+          />
+        </Index>
+      </>
+    );
+  }
+);
+
+const Suggestions = connectHits(function Suggestions(props) {
   React.useEffect(() => {
     if (props.hits.length === 0) {
       props.onSuggestion(null);

--- a/src/components/SearchBox/ConnectedSearchBox.js
+++ b/src/components/SearchBox/ConnectedSearchBox.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { connectSearchBox } from 'react-instantsearch-dom';
 
-import { SearchBox } from './SearchBox';
+import { SearchBox as SearchBoxComponent } from './SearchBox';
 
-export const ConnectedSearchBox = connectSearchBox((props) => {
+export const ConnectedSearchBox = connectSearchBox(function SearchBox(props) {
   return (
-    <SearchBox
+    <SearchBoxComponent
       translations={{ placeholder: 'Search for a product, brand, color, …' }}
       {...props}
       onChange={(event) => {

--- a/src/components/SizeList.js
+++ b/src/components/SizeList.js
@@ -5,7 +5,7 @@ import { FacetSearchBox } from './SearchBox/FacetSearchBox';
 import { PartialHighlight } from './PartialHighlight';
 import { PanelWrapper } from './Panel';
 
-export const SizeList = connectRefinementList((props) => {
+export const SizeList = connectRefinementList(function SizeList(props) {
   const [query, setQuery] = React.useState('');
   const inputRef = React.useRef(null);
 

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -6,7 +6,7 @@ import './Slider.scss';
 
 import { PanelWrapper } from './Panel';
 
-export const Slider = connectRange((props) => {
+export const Slider = connectRange(function Slider(props) {
   const {
     min,
     max,

--- a/src/components/Stats.js
+++ b/src/components/Stats.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connectStats } from 'react-instantsearch-dom';
 
-export const Stats = connectStats((props) => {
+export const Stats = connectStats(function Stats(props) {
   return (
     <div className="ais-Stats">
       <span className="ais-Stats-text">


### PR DESCRIPTION
I was debugging an issue with the panel context that triggers to many renders and conflicts with InstantSearch lifecycle when I realized that our components were not named and therefore difficult to debug with React DevTools.

## Before

![image](https://user-images.githubusercontent.com/6137112/79982947-55ac9500-84a7-11ea-8576-2c4a804f157e.png)

## After

![image](https://user-images.githubusercontent.com/6137112/79982812-285fe700-84a7-11ea-9d58-85bae9491b6b.png)
