### PR TITLE
build: enable transpiling for IE 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "browserslist": [
     "> 0.2%",
     "not dead",
-    "not ie <= 11",
+    "not ie < 11",
     "not op_mini all"
   ]
 }


### PR DESCRIPTION
The build (generated with Create React App, the one that currently bundles the Netlify build) doesn't work on IE11 because Babel doesn't transpile down to it. This fixes it

## Notes

We still have to configure it to work the same with our custom `build` command.