### PR TITLE
feat(router): support pop state event

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -67,7 +67,7 @@ export function App({ config }) {
   // Handle the browser pop state event to open the search overlay if the
   // next URL maps to a search state.
   React.useEffect(() => {
-    window.onpopstate = () => {
+    function onPopState() {
       if (isOverlayShowing === true) {
         return;
       }
@@ -77,6 +77,12 @@ export function App({ config }) {
       if (Object.keys(nextSearchState).length > 0) {
         setIsOverlayShowing(true);
       }
+    }
+
+    window.addEventListener('popstate', onPopState);
+
+    return () => {
+      window.removeEventListener('popstate', onPopState);
     };
   }, [isOverlayShowing, setIsOverlayShowing]);
 


### PR DESCRIPTION
This adds support for the `popstate` window event to open the overlay when coming from the website and using the back browser button.

How to use:

1. Load the website
2. Trigger a search
3. Close the overlay
4. Hit browser back button
5. Notice that the search overlay opens

Note that the effects are quite messy and we ignore `react-hooks/exhaustive-deps` while we shouldn't, but I'm not sure how avoid that. The main reason is that we're supposed to track `searchState` according to the `useEffect` rule but listening to this triggers infinite loop. Conceptually, we don't really want to listen to its change, but only to use it when other dependencies changes. I plan to rework the whole router anyway so I think we can go with that for now.