### PR TITLE
fix: detach Query Suggestions index from main index

### DIFF
--- a/src/components/SearchBox/PredictiveSearchBox.js
+++ b/src/components/SearchBox/PredictiveSearchBox.js
@@ -42,7 +42,7 @@ export const PredictiveSearchBox = (props) => {
       />
 
       <Index indexName={QUERY_SUGGESTIONS_INDEX_NAME}>
-        <Configure page={0} {...props.suggestionsIndex.searchParameters} />
+        <Configure {...props.suggestionsIndex.searchParameters} />
         <Suggestions
           query={props.currentRefinement}
           onSuggestion={(suggestion) => setCurrentSuggestion(suggestion)}

--- a/src/hooks/useSearchClient.js
+++ b/src/hooks/useSearchClient.js
@@ -20,6 +20,7 @@ export function useSearchClient(config) {
         const modifiedRequests = requests.map((searchParameters) => {
           const detachedSearchParams = {
             ...searchParameters.params,
+            page: 0,
             facetFilters: [],
             numericFilters: [],
             optionalFilters: [],


### PR DESCRIPTION
This "detaches" the QS index from the main one by ignoring all filters applied. All detached indices now ignore all facets, because it could make some requests fail when e.g. you use the price slider; it sets numeric filters on a QS index that is not set to support numeric filters.