### PR TITLE
feat(hit): lazy load images

### DIFF
--- a/src/config/Hit.js
+++ b/src/config/Hit.js
@@ -15,7 +15,7 @@ export function Hit({ hit, insights, view }) {
     >
       <a href={`https://asos.com/${hit.url}`} className="uni-Hit-inner">
         <div className="uni-Hit-image">
-          <img src={hit.image} alt={hit.description} />
+          <img src={hit.image} alt={hit.description} loading="lazy" />
         </div>
 
         <div className="uni-Hit-Body">


### PR DESCRIPTION
This lazy loads images for browsers supporting the `loading` attribute on images.

Later, we can use a JavaScript solution to lazy load images in all browsers if we consider it necessary.

See: https://addyosmani.com/blog/lazy-loading/