### PR TITLE
fix(config): allow missing Query Suggestions index

### DIFF
--- a/src/components/NoResultsHandler.js
+++ b/src/components/NoResultsHandler.js
@@ -134,7 +134,11 @@ const HitsPreview = connectHits(function MoreHits(props) {
 });
 
 function QuerySuggestions() {
-  const { searchState, searchParameters } = useAppContext();
+  const { config, searchState, searchParameters } = useAppContext();
+
+  if (!config.suggestionsIndex) {
+    return null;
+  }
 
   return (
     <Index indexName={QUERY_SUGGESTIONS_INDEX_NAME}>

--- a/src/hooks/useSearchClient.js
+++ b/src/hooks/useSearchClient.js
@@ -42,6 +42,12 @@ export function useSearchClient(config) {
           } else if (
             searchParameters.indexName === QUERY_SUGGESTIONS_INDEX_NAME
           ) {
+            if (!config.suggestionsIndex) {
+              throw new Error(
+                'A search request was sent to the Query Suggestions index but the index name is not specified in the user configuration (`suggestionsIndex.indexName`).'
+              );
+            }
+
             return {
               ...searchParameters,
               indexName: config.suggestionsIndex.indexName,
@@ -55,12 +61,7 @@ export function useSearchClient(config) {
         return client.search(modifiedRequests);
       },
     };
-  }, [
-    appId,
-    apiKey,
-    config.index.indexName,
-    config.suggestionsIndex.indexName,
-  ]);
+  }, [appId, apiKey, config.index.indexName, config.suggestionsIndex]);
 
   return searchClient;
 }


### PR DESCRIPTION
This allows a functioning app without specifying a Query Suggestions index because not all users will have access to this feature.