### PR TITLE
fix: disable auto-hide behavior in panels

### DIFF
--- a/src/components/ColorList.js
+++ b/src/components/ColorList.js
@@ -4,7 +4,6 @@ import { connectRefinementList } from 'react-instantsearch-dom';
 import './ColorList.scss';
 import { FacetSearchBox } from './SearchBox/FacetSearchBox';
 import { PartialHighlight } from './PartialHighlight';
-import { PanelWrapper } from './Panel';
 
 export const ColorList = connectRefinementList(function ColorList(props) {
   const [query, setQuery] = React.useState('');
@@ -19,104 +18,100 @@ export const ColorList = connectRefinementList(function ColorList(props) {
   });
 
   return (
-    <PanelWrapper {...props}>
-      <div className="ais-ColorList ais-RefinementList">
-        {props.searchable && (
-          <div className="ais-RefinementList-searchBox">
-            <FacetSearchBox
-              inputRef={inputRef}
-              translations={{ placeholder: 'Search colors' }}
-              query={query}
-              onChange={(event) => {
-                const value = event.currentTarget.value;
-                setQuery(value);
-                props.searchForItems(value);
-              }}
-              onSubmit={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
+    <div className="ais-ColorList ais-RefinementList">
+      {props.searchable && (
+        <div className="ais-RefinementList-searchBox">
+          <FacetSearchBox
+            inputRef={inputRef}
+            translations={{ placeholder: 'Search colors' }}
+            query={query}
+            onChange={(event) => {
+              const value = event.currentTarget.value;
+              setQuery(value);
+              props.searchForItems(value);
+            }}
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
 
-                if (props.isFromSearch && props.items.length > 0) {
-                  props.refine(props.items[0].value);
-                  setQuery('');
-                }
-
-                if (inputRef.current) {
-                  inputRef.current.blur();
-                }
-              }}
-              onReset={() => {
+              if (props.isFromSearch && props.items.length > 0) {
+                props.refine(props.items[0].value);
                 setQuery('');
-                props.searchForItems('');
-
-                if (inputRef.current) {
-                  inputRef.current.focus();
-                }
-              }}
-            />
-          </div>
-        )}
-
-        <div className="uni-RefinementList-ListContainer">
-          {props.isFromSearch && props.items.length === 0 && (
-            <p>No colors found.</p>
-          )}
-
-          <ul className="ais-RefinementList-list">
-            {props.items.map((item) => {
-              const labelParts = item.label.split(';');
-
-              if (labelParts.length !== 2) {
-                throw new Error(
-                  `The Color widget expects colors with the following format: "Aluminium;#7f8084". Received "${item.label}".`
-                );
               }
 
-              const [colorName, colorCode] = labelParts;
+              if (inputRef.current) {
+                inputRef.current.blur();
+              }
+            }}
+            onReset={() => {
+              setQuery('');
+              props.searchForItems('');
 
-              return (
-                <li
-                  key={item.label}
-                  className={[
-                    'ais-RefinementList-item',
-                    item.isRefined && 'ais-RefinementList-item--selected',
-                  ]
-                    .filter(Boolean)
-                    .join(' ')}
-                >
-                  <label className="ais-RefinementList-label">
-                    <input
-                      className="ais-RefinementList-checkbox"
-                      style={{
-                        color: colorCode,
-                        backgroundColor: colorCode,
-                      }}
-                      type="checkbox"
-                      value={item.value}
-                      checked={item.isRefined}
-                      onChange={(event) => {
-                        event.preventDefault();
-                        props.refine(item.value);
-                        setQuery('');
-                      }}
-                    />
-                    <span className="ais-RefinementList-labelText">
-                      {props.isFromSearch ? (
-                        <PartialHighlight hit={item} attribute="label" />
-                      ) : (
-                        colorName
-                      )}
-                    </span>
-                    <span className="ais-RefinementList-count">
-                      {item.count}
-                    </span>
-                  </label>
-                </li>
-              );
-            })}
-          </ul>
+              if (inputRef.current) {
+                inputRef.current.focus();
+              }
+            }}
+          />
         </div>
+      )}
+
+      <div className="uni-RefinementList-ListContainer">
+        {props.isFromSearch && props.items.length === 0 && (
+          <p>No colors found.</p>
+        )}
+
+        <ul className="ais-RefinementList-list">
+          {props.items.map((item) => {
+            const labelParts = item.label.split(';');
+
+            if (labelParts.length !== 2) {
+              throw new Error(
+                `The Color widget expects colors with the following format: "Aluminium;#7f8084". Received "${item.label}".`
+              );
+            }
+
+            const [colorName, colorCode] = labelParts;
+
+            return (
+              <li
+                key={item.label}
+                className={[
+                  'ais-RefinementList-item',
+                  item.isRefined && 'ais-RefinementList-item--selected',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                <label className="ais-RefinementList-label">
+                  <input
+                    className="ais-RefinementList-checkbox"
+                    style={{
+                      color: colorCode,
+                      backgroundColor: colorCode,
+                    }}
+                    type="checkbox"
+                    value={item.value}
+                    checked={item.isRefined}
+                    onChange={(event) => {
+                      event.preventDefault();
+                      props.refine(item.value);
+                      setQuery('');
+                    }}
+                  />
+                  <span className="ais-RefinementList-labelText">
+                    {props.isFromSearch ? (
+                      <PartialHighlight hit={item} attribute="label" />
+                    ) : (
+                      colorName
+                    )}
+                  </span>
+                  <span className="ais-RefinementList-count">{item.count}</span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
       </div>
-    </PanelWrapper>
+    </div>
   );
 });

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -2,18 +2,6 @@ import React from 'react';
 
 import './Panel.scss';
 
-const PanelContext = React.createContext();
-
-function usePanelContext() {
-  const context = React.useContext(PanelContext);
-
-  if (!context) {
-    throw new Error('`usePanelContext` must be used within a Panel.');
-  }
-
-  return context;
-}
-
 export function Panel({
   isOpened: initialIsOpened = true,
   header,
@@ -22,14 +10,12 @@ export function Panel({
   ...rest
 }) {
   const [isOpened, setIsOpened] = React.useState(initialIsOpened);
-  const [canRefine, setCanRefine] = React.useState(true);
 
   return (
     <div
       className={[
         'ais-Panel',
         'ais-Panel--collapsible',
-        canRefine === false && 'ais-Panel-noRefinement',
         isOpened === false && 'ais-Panel--collapsed',
       ]
         .filter(Boolean)
@@ -62,22 +48,9 @@ export function Panel({
         </button>
       </div>
 
-      <div className="ais-Panel-body">
-        <PanelContext.Provider value={{ setCanRefine }}>
-          {children}
-        </PanelContext.Provider>
-      </div>
+      <div className="ais-Panel-body">{children}</div>
 
       {footer && <div className="ais-Panel-footer">{footer}</div>}
     </div>
   );
 }
-export const PanelWrapper = (props) => {
-  const { setCanRefine } = usePanelContext();
-
-  React.useEffect(() => {
-    setCanRefine(props.canRefine);
-  }, [setCanRefine, props.canRefine, props.isFromSearch]);
-
-  return props.children;
-};

--- a/src/components/SizeList.js
+++ b/src/components/SizeList.js
@@ -3,7 +3,6 @@ import { connectRefinementList } from 'react-instantsearch-dom';
 
 import { FacetSearchBox } from './SearchBox/FacetSearchBox';
 import { PartialHighlight } from './PartialHighlight';
-import { PanelWrapper } from './Panel';
 
 export const SizeList = connectRefinementList(function SizeList(props) {
   const [query, setQuery] = React.useState('');
@@ -18,100 +17,96 @@ export const SizeList = connectRefinementList(function SizeList(props) {
   });
 
   return (
-    <PanelWrapper {...props}>
-      <div className="ais-RefinementList">
-        {props.searchable && (
-          <div className="ais-RefinementList-searchBox">
-            <FacetSearchBox
-              inputRef={inputRef}
-              translations={{ placeholder: 'Search sizes' }}
-              query={query}
-              onChange={(event) => {
-                const value = event.currentTarget.value;
-                setQuery(value);
-                props.searchForItems(value);
-              }}
-              onSubmit={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
+    <div className="ais-RefinementList">
+      {props.searchable && (
+        <div className="ais-RefinementList-searchBox">
+          <FacetSearchBox
+            inputRef={inputRef}
+            translations={{ placeholder: 'Search sizes' }}
+            query={query}
+            onChange={(event) => {
+              const value = event.currentTarget.value;
+              setQuery(value);
+              props.searchForItems(value);
+            }}
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
 
-                if (props.isFromSearch && props.items.length > 0) {
-                  props.refine(props.items[0].value);
-                  setQuery('');
-                }
-
-                if (inputRef.current) {
-                  inputRef.current.blur();
-                }
-              }}
-              onReset={() => {
+              if (props.isFromSearch && props.items.length > 0) {
+                props.refine(props.items[0].value);
                 setQuery('');
-                props.searchForItems('');
-
-                if (inputRef.current) {
-                  inputRef.current.focus();
-                }
-              }}
-            />
-          </div>
-        )}
-
-        <div className="uni-RefinementList-ListContainer">
-          {props.isFromSearch && props.items.length === 0 && (
-            <p>No sizes found.</p>
-          )}
-
-          <ul className="ais-RefinementList-list">
-            {props.items.map((item) => {
-              const labelParts = item.label.split(';');
-
-              if (labelParts.length < 2) {
-                throw new Error(
-                  `The Size widget expects sizes with the following format: "XL;6". Received "${item.label}".`
-                );
               }
 
-              const [sizeName] = labelParts;
+              if (inputRef.current) {
+                inputRef.current.blur();
+              }
+            }}
+            onReset={() => {
+              setQuery('');
+              props.searchForItems('');
 
-              return (
-                <li
-                  key={item.label}
-                  className={[
-                    'ais-RefinementList-item',
-                    item.isRefined && 'ais-RefinementList-item--selected',
-                  ]
-                    .filter(Boolean)
-                    .join(' ')}
-                >
-                  <label className="ais-RefinementList-label">
-                    <input
-                      className="ais-RefinementList-checkbox"
-                      type="checkbox"
-                      value={item.value}
-                      checked={item.isRefined}
-                      onChange={(event) => {
-                        event.preventDefault();
-                        props.refine(item.value);
-                        setQuery('');
-                      }}
-                    />
-                    <span className="ais-RefinementList-labelText">
-                      {props.isFromSearch ? (
-                        <PartialHighlight hit={item} attribute="label" />
-                      ) : (
-                        sizeName
-                      )}
-                    </span>
-                    <span className="ais-RefinementList-count">
-                      {item.count}
-                    </span>
-                  </label>
-                </li>
-              );
-            })}
-          </ul>
+              if (inputRef.current) {
+                inputRef.current.focus();
+              }
+            }}
+          />
         </div>
+      )}
+
+      <div className="uni-RefinementList-ListContainer">
+        {props.isFromSearch && props.items.length === 0 && (
+          <p>No sizes found.</p>
+        )}
+
+        <ul className="ais-RefinementList-list">
+          {props.items.map((item) => {
+            const labelParts = item.label.split(';');
+
+            if (labelParts.length < 2) {
+              throw new Error(
+                `The Size widget expects sizes with the following format: "XL;6". Received "${item.label}".`
+              );
+            }
+
+            const [sizeName] = labelParts;
+
+            return (
+              <li
+                key={item.label}
+                className={[
+                  'ais-RefinementList-item',
+                  item.isRefined && 'ais-RefinementList-item--selected',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                <label className="ais-RefinementList-label">
+                  <input
+                    className="ais-RefinementList-checkbox"
+                    type="checkbox"
+                    value={item.value}
+                    checked={item.isRefined}
+                    onChange={(event) => {
+                      event.preventDefault();
+                      props.refine(item.value);
+                      setQuery('');
+                    }}
+                  />
+                  <span className="ais-RefinementList-labelText">
+                    {props.isFromSearch ? (
+                      <PartialHighlight hit={item} attribute="label" />
+                    ) : (
+                      sizeName
+                    )}
+                  </span>
+                  <span className="ais-RefinementList-count">{item.count}</span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
       </div>
-    </PanelWrapper>
+    </div>
   );
 });

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -4,8 +4,6 @@ import Rheostat from 'rheostat';
 
 import './Slider.scss';
 
-import { PanelWrapper } from './Panel';
-
 export const Slider = connectRange(function Slider(props) {
   const {
     min,
@@ -58,33 +56,31 @@ export const Slider = connectRange(function Slider(props) {
   }, [min, max]);
 
   if (min === max) {
-    return <PanelWrapper {...props}>{null}</PanelWrapper>;
+    return null;
   }
 
   return (
-    <PanelWrapper {...props}>
-      <div className="uni-Slider">
-        <div className="uni-Slider-bar">
-          <Rheostat
-            className="uni-Rheostat"
-            min={min}
-            max={max}
-            snap={true}
-            values={[currentRefinement.min, currentRefinement.max]}
-            onChange={onChange}
-            onValuesUpdated={onValuesUpdated}
-          />
-        </div>
+    <div className="uni-Slider">
+      <div className="uni-Slider-bar">
+        <Rheostat
+          className="uni-Rheostat"
+          min={min}
+          max={max}
+          snap={true}
+          values={[currentRefinement.min, currentRefinement.max]}
+          onChange={onChange}
+          onValuesUpdated={onValuesUpdated}
+        />
+      </div>
 
-        <div className="uni-Slider-values">
-          <div className="uni-Slider-value uni-Slider-value--min">
-            {transformValue(currentMin)}
-          </div>
-          <div className="uni-Slider-value uni-Slider-value--max">
-            {transformValue(currentMax)}
-          </div>
+      <div className="uni-Slider-values">
+        <div className="uni-Slider-value uni-Slider-value--min">
+          {transformValue(currentMin)}
+        </div>
+        <div className="uni-Slider-value uni-Slider-value--max">
+          {transformValue(currentMax)}
         </div>
       </div>
-    </PanelWrapper>
+    </div>
   );
 });


### PR DESCRIPTION
Auto-hiding panels was buggy because of too many renders InstantSearch triggered. Let's remove this feature until we get it right.