### PR TITLE
fix: don't use stale mobile breakpoint values

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import { connectHitInsights } from 'react-instantsearch-dom';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { getUrlFromState, getStateFromUrl, createURL } from './router';
-import { useSearchClient, useInsights } from './hooks';
+import { useSearchClient, useInsights, useMatchMedia } from './hooks';
 import { SearchButton, Search } from './components';
 
 export const AppContext = React.createContext(null);
@@ -19,6 +19,7 @@ export function App({ config }) {
     config.searchApiKey,
     config.setUserToken
   );
+  const { isMobile } = useMatchMedia(config);
   const lastSetStateId = React.useRef();
   const topAnchor = React.useRef();
   const [searchState, setSearchState] = React.useState(
@@ -28,7 +29,6 @@ export function App({ config }) {
     Object.keys(searchState).length > 0
   );
   const [isFiltering, setIsFiltering] = React.useState(false);
-  const [isMobile, setIsMobile] = React.useState(true);
   const [view, setView] = React.useState('grid');
   const searchContextRef = React.useRef({});
   const searchParameters = {
@@ -159,15 +159,6 @@ export function App({ config }) {
       window.removeEventListener('keydown', onKeydown);
     };
   }, [isOverlayShowing, setIsOverlayShowing, config.keyboardShortcuts]);
-
-  React.useEffect(() => {
-    if (
-      window.matchMedia(`(min-width: ${config.styles.breakpoints.sm}px)`)
-        .matches
-    ) {
-      setIsMobile(false);
-    }
-  }, []);
 
   return (
     <AppContext.Provider

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,5 +1,6 @@
 export * from './useAppContext';
 export * from './useIntersectionObserver';
 export * from './useInsights';
+export * from './useMatchMedia';
 export * from './useSearchClient';
 export * from './useSearchContext';

--- a/src/hooks/useMatchMedia.js
+++ b/src/hooks/useMatchMedia.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export function useMatchMedia(config) {
+  const [isMobile, setIsMobile] = React.useState(
+    () =>
+      !window.matchMedia(`(min-width: ${config.styles.breakpoints.sm}px)`)
+        .matches
+  );
+
+  React.useEffect(() => {
+    function onChange(event) {
+      setIsMobile(!event.matches);
+    }
+
+    const mediaQuery = window.matchMedia(
+      `(min-width: ${config.styles.breakpoints.sm}px)`
+    );
+
+    mediaQuery.addListener(onChange);
+
+    return () => {
+      mediaQuery.removeListener(onChange);
+    };
+  }, [config.styles.breakpoints.sm]);
+
+  return { isMobile };
+}


### PR DESCRIPTION
This improves mobile detection by not using an arbitrary initial value for `isMobile`, and keeping the browser viewport in sync with the value with `matchMedia` event listeners.