### PR TITLE
fix(slider): synchronize min and max values with routing

### DIFF
--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -12,8 +12,8 @@ export const Slider = connectRange(function Slider(props) {
     refine,
     transformValue = (x) => x,
   } = props;
-  const [currentMin, setCurrentMin] = React.useState(null);
-  const [currentMax, setCurrentMax] = React.useState(null);
+  const [currentMin, setCurrentMin] = React.useState(currentRefinement.min);
+  const [currentMax, setCurrentMax] = React.useState(currentRefinement.max);
 
   function computeMinValue(value) {
     return Math.min(Math.max(value, min), max);
@@ -28,18 +28,9 @@ export const Slider = connectRange(function Slider(props) {
       currentRefinement.min !== values[0] ||
       currentRefinement.max !== values[1]
     ) {
-      let computedMin = computeMinValue(values[0]);
-      let computedMax = computeMaxValue(values[1]);
-
-      if (computedMin === computedMax && computedMin > min) {
-        computedMin -= 1;
-      } else if (computedMin === computedMax && computedMax < max) {
-        computedMax += 1;
-      }
-
       refine({
-        min: computedMin,
-        max: computedMax,
+        min: currentMin,
+        max: currentMax,
       });
     }
   }
@@ -51,9 +42,14 @@ export const Slider = connectRange(function Slider(props) {
 
   // `min` and `max` values are passed as `undefined` on the first render.
   React.useEffect(() => {
-    setCurrentMin(min);
-    setCurrentMax(max);
-  }, [min, max]);
+    if (currentMin === undefined) {
+      setCurrentMin(min);
+    }
+
+    if (currentMax === undefined) {
+      setCurrentMax(max);
+    }
+  }, [min, max, currentMin, currentMax, setCurrentMin, setCurrentMax]);
 
   if (min === max) {
     return null;


### PR DESCRIPTION
## Description

The previous slider implementation didn't keep min and max values synced with the URL.

## Preview

- [Before](https://next--ecomm-unified-algolia.netlify.app/?range%5Bprice%5D%5Bmin%5D=472&range%5Bprice%5D%5Bmax%5D=3976) (notice that slider values are wrong: `1` and `5000`)
- [After](https://deploy-preview-79--ecomm-unified-algolia.netlify.app/?range%5Bprice%5D%5Bmin%5D=472&range%5Bprice%5D%5Bmax%5D=3976) (notice that slider values are right)