### PR TITLE
fix: avoid infinite loop in no results screen

### DIFF
--- a/src/components/NoResultsHandler.js
+++ b/src/components/NoResultsHandler.js
@@ -82,13 +82,20 @@ const ResultsInAllCategories = connectCurrentRefinements(function ClearFilters(
           query={searchState.query}
           hitsPerPage={4}
         />
-        <HitsPreview
-          onSeeAllClick={(event) => {
+        <HitsPreview />
+      </Index>
+
+      <div className="uni-NoResults-SeeAll">
+        <button
+          className="uni-NoResults-SeeAllButton"
+          onClick={(event) => {
             event.preventDefault();
             props.refine(props.items);
           }}
-        />
-      </Index>
+        >
+          See results in all categories
+        </button>
+      </div>
     </>
   );
 });
@@ -119,15 +126,6 @@ const HitsPreview = connectHits(function MoreHits(props) {
             </li>
           ))}
         </ol>
-      </div>
-
-      <div className="uni-NoResults-SeeAll">
-        <button
-          className="uni-NoResults-SeeAllButton"
-          onClick={props.onSeeAllClick}
-        >
-          See results in all categories
-        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

This fixes the infinite loop issue on the no results screen when we fetch hits from the index without filters.

As soon as we pass a prop to a component using `connectHits`, it freezes. I therefore moved the button to see all results outside of the hits component.

The bug (or at least a similar bug) is known in React InstantSearch but we're not sure about the cause.

See:

- https://github.com/algolia/instantsearch.js/issues/5266
- https://github.com/algolia/react-instantsearch/issues/2795
- https://github.com/algolia/instantsearch.js/issues/5269

## Preview

- [Before](https://next--ecomm-unified-algolia.netlify.app/?query=skin%20ca&refinementList[brand][0]=vans) ⚠️ it crashes the browser
- [After](https://deploy-preview-80--ecomm-unified-algolia.netlify.app/?query=skin%20ca&refinementList[brand][0]=vans)