### PR TITLE
feat(mobile): add accordion effect to panels

### DIFF
--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -3,14 +3,13 @@ import React from 'react';
 import './Panel.scss';
 
 export function Panel({
-  isOpened: initialIsOpened = true,
+  isOpened,
   header,
   footer,
+  onToggle,
   children,
   ...rest
 }) {
-  const [isOpened, setIsOpened] = React.useState(initialIsOpened);
-
   return (
     <div
       className={[
@@ -26,7 +25,7 @@ export function Panel({
         <button
           className="ais-Panel-headerButton"
           aria-expanded={isOpened}
-          onClick={() => setIsOpened((prevValue) => !prevValue)}
+          onClick={onToggle}
         >
           <div>{header}</div>
 


### PR DESCRIPTION
This makes the `Panel` component uncontrolled to manipulate their open state in the `Refinements` component. This allows to toggle panels as before on desktop, but to collapse them with an accordion effect on mobile.

This will have the fully expected behavior when merged with #78 which tracks the `isMobile` context value.