### PR TITLE
fix: prevent body scroll when open

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,5 +1,9 @@
 @import './config/variables';
 
+.uni--open {
+  overflow: hidden;
+}
+
 /* Loading */
 
 .uni-LoadingProgress {


### PR DESCRIPTION
When the website behind the overlay is scrollable (see #91), we should prevent it from scrolling when the search is opened.