### PR TITLE
feat(searchbox): reset query on Escape

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -141,7 +141,7 @@ export function App({ config }) {
       }
 
       if (isOverlayShowing) {
-        if (event.key === 'Escape') {
+        if (event.keyCode === 27) {
           event.stopPropagation();
           event.preventDefault();
           setIsOverlayShowing(false);

--- a/src/components/SearchBox/ConnectedSearchBox.js
+++ b/src/components/SearchBox/ConnectedSearchBox.js
@@ -39,7 +39,7 @@ export const HeaderSearchBox = connectSearchBox(function SearchBox(props) {
           props.refine(event.currentTarget.value);
         }}
         onKeyDown={(event) => {
-          if (event.key === 'Escape') {
+          if (event.keyCode === 27) {
             event.preventDefault();
             props.refine('');
           }

--- a/src/components/SearchBox/PredictiveSearchBox.js
+++ b/src/components/SearchBox/PredictiveSearchBox.js
@@ -33,7 +33,7 @@ export const PredictiveSearchBox = (props) => {
           ) {
             event.preventDefault();
             props.refine(suggestion);
-          } else if (event.key === 'Escape') {
+          } else if (event.keyCode === 27) {
             event.preventDefault();
             props.refine('');
           }


### PR DESCRIPTION
This supports the default behavior that search inputs have when hitting the "Escape" key: reset the input.