### PR TITLE
fix: fix input completion offset

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -109,6 +109,7 @@
   .ais-SearchBox-input,
   .ais-SearchBox-completion {
     background: none;
+    border-bottom: 1px solid transparent;
     height: 100%;
     padding: 0 48px;
     position: absolute;


### PR DESCRIPTION
This fixes a one-off offset on the input completion.

### Chrome

![Capture d’écran 2020-05-07 à 12 30 00](https://user-images.githubusercontent.com/5370675/81284646-a94ddf80-905e-11ea-8465-d95b543213a8.png)

### Firefox

![Capture d’écran 2020-05-07 à 12 29 52](https://user-images.githubusercontent.com/5370675/81284631-a521c200-905e-11ea-8ed3-2ac9f3aecb3f.png)

### Safari

![Capture d’écran 2020-05-07 à 12 30 07](https://user-images.githubusercontent.com/5370675/81284663-aeab2a00-905e-11ea-90e2-06d7851f31cd.png)

### IE 11

![Capture d’écran 2020-05-07 à 12 29 46](https://user-images.githubusercontent.com/5370675/81284612-9affc380-905e-11ea-94f1-3b7eadd8698d.png)
