### PR TITLE
docs: update export command order

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Follow the few steps described below to start using Unified InstantSearch E-Comm
 1. **Push your data to Algolia** (following the [required data schema](#customizing-the-search-ui)),
 2. [**Fork this GitHub repository**](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) to your own,
 3. **Replace the values in `src/config/index.js`** to better match your needs,
-4. **Run `npm run export` (or `yarn export`)** to build the JS and CSS files,
+4. **Run `yarn export` (or `npm run export`)** to build the JS and CSS files,
 5. **Host and include the generated JS and CSS files** on your front-end and start using!
 
 ### Instructions


### PR DESCRIPTION
We use `yarn` before `npm` in all the other console snippets.