### PR TITLE
feat(pagination): scroll to top on page change

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -176,6 +176,7 @@ export function App({ config }) {
         setSearchContext,
         ConnectedHit,
         isMobile,
+        topAnchor,
       }}
     >
       <SearchButton onClick={() => setIsOverlayShowing(true)} />

--- a/src/components/Hits.js
+++ b/src/components/Hits.js
@@ -1,10 +1,18 @@
 import React from 'react';
-import { connectHits, Pagination } from 'react-instantsearch-dom';
+import { connectHits } from 'react-instantsearch-dom';
 
 import { useAppContext } from '../hooks';
+import { Pagination } from './Pagination';
 
 export const Hits = connectHits((props) => {
-  const { view, ConnectedHit } = useAppContext();
+  const { view, ConnectedHit, topAnchor } = useAppContext();
+
+  const onPageClick = React.useCallback(
+    function onPageClick() {
+      topAnchor.current.scrollTop = 0;
+    },
+    [topAnchor]
+  );
 
   return (
     <div className="ais-Hits">
@@ -21,40 +29,7 @@ export const Hits = connectHits((props) => {
         ))}
       </ol>
 
-      <Pagination
-        showFirst={false}
-        padding={2}
-        translations={{
-          previous: (
-            <svg width={10} height={10} viewBox="0 0 10 10">
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="1.143"
-              >
-                <path d="M9 5H1M5 9L1 5l4-4" />
-              </g>
-            </svg>
-          ),
-          next: (
-            <svg width={10} height={10} viewBox="0 0 10 10">
-              <g
-                fill="none"
-                fillRule="evenodd"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="1.143"
-              >
-                <path d="M1 5h8M5 9l4-4-4-4" />
-              </g>
-            </svg>
-          ),
-        }}
-      />
+      <Pagination onClick={onPageClick} />
     </div>
   );
 });

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import { connectPagination } from 'react-instantsearch-dom';
+
+export const Pagination = connectPagination(function Pagination(props) {
+  if (props.canRefine === false) {
+    return null;
+  }
+
+  const pages = getPages(props.currentRefinement, props.nbPages, 2);
+
+  function onPageClick(page) {
+    props.refine(page);
+    props.onClick();
+  }
+
+  return (
+    <div className="ais-Pagination">
+      <ul className="ais-Pagination-list">
+        {props.currentRefinement !== 1 && (
+          <li className="ais-Pagination-item ais-Pagination-item--previousPage">
+            <a
+              className="ais-Pagination-link"
+              title="Previous page"
+              href={props.createURL(props.currentRefinement - 1)}
+              onClick={(event) => {
+                event.preventDefault();
+                onPageClick(props.currentRefinement - 1);
+              }}
+            >
+              <svg width={10} height={10} viewBox="0 0 10 10">
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.143"
+                >
+                  <path d="M9 5H1M5 9L1 5l4-4" />
+                </g>
+              </svg>
+            </a>
+          </li>
+        )}
+
+        {pages.map((page) => (
+          <li
+            className={[
+              'ais-Pagination-item',
+              'ais-Pagination-item--page',
+              props.currentRefinement === page &&
+                'ais-Pagination-item--selected',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            key={page}
+          >
+            <a
+              className="ais-Pagination-link"
+              title={`Page ${page}`}
+              href={props.createURL(page)}
+              onClick={(event) => {
+                event.preventDefault();
+                onPageClick(page);
+              }}
+            >
+              {page}
+            </a>
+          </li>
+        ))}
+
+        {props.currentRefinement !== props.nbPages && (
+          <li className="ais-Pagination-item ais-Pagination-item--nextPage">
+            <a
+              className="ais-Pagination-link"
+              title="Next page"
+              href={props.createURL(props.currentRefinement + 1)}
+              onClick={(event) => {
+                event.preventDefault();
+                onPageClick(props.currentRefinement + 1);
+              }}
+            >
+              <svg width={10} height={10} viewBox="0 0 10 10">
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.143"
+                >
+                  <path d="M1 5h8M5 9l4-4-4-4" />
+                </g>
+              </svg>
+            </a>
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+});
+
+function getPaddingLeft(currentPage, padding, maxPages, size) {
+  if (currentPage <= padding) {
+    return currentPage;
+  }
+
+  if (currentPage >= maxPages - padding) {
+    return size - (maxPages - currentPage);
+  }
+
+  return padding + 1;
+}
+
+function getPages(currentPage, maxPages, padding) {
+  const size = Math.min(2 * padding + 1, maxPages);
+
+  if (size === maxPages) {
+    return range({ start: 1, end: maxPages + 1 });
+  }
+
+  const paddingLeft = getPaddingLeft(currentPage, padding, maxPages, size);
+  const paddingRight = size - paddingLeft;
+
+  const first = currentPage - paddingLeft;
+  const last = currentPage + paddingRight;
+
+  return range({ start: first + 1, end: last + 1 });
+}
+
+function range({ start = 0, end, step = 1 }) {
+  // We can't divide by 0 so we re-assign the step to 1 if it happens.
+  const limitStep = step === 0 ? 1 : step;
+
+  // In some cases the array to create has a decimal length.
+  // We therefore need to round the value.
+  // Example:
+  //   { start: 1, end: 5000, step: 500 }
+  //   => Array length = (5000 - 1) / 500 = 9.998
+  const arrayLength = Math.round((end - start) / limitStep);
+
+  return [...Array(arrayLength)].map(
+    (_, current) => (start + current) * limitStep
+  );
+}

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  InstantSearch,
-  Configure,
-  SortBy,
-  ScrollTo,
-} from 'react-instantsearch-dom';
+import { InstantSearch, Configure, SortBy } from 'react-instantsearch-dom';
 
 import { useAppContext, useSearchContext } from '../hooks';
 import { Banner } from './Banner';
@@ -102,39 +97,37 @@ export function Search(props) {
           </div>
 
           <div className="uni-RightPanel">
-            <ScrollTo>
-              <header className="uni-BodyHeader">
-                <div className="uni-BodyHeader-heading">
-                  <div className="uni-BodyHeader-stats">
-                    <Stats />
-                  </div>
+            <header className="uni-BodyHeader">
+              <div className="uni-BodyHeader-heading">
+                <div className="uni-BodyHeader-stats">
+                  <Stats />
+                </div>
 
-                  <div className="uni-BodyHeader-extraOptions">
-                    {config.sorts?.length > 0 && (
-                      <div className="uni-BodyHeader-sortBy">
-                        <span className="uni-Label">Sort by</span>
-                        <SortBy
-                          items={config.sorts}
-                          defaultRefinement={config.sorts[0].value}
-                        />
-                      </div>
-                    )}
-
-                    <div>
-                      <Views view={view} setView={props.setView} />
+                <div className="uni-BodyHeader-extraOptions">
+                  {config.sorts?.length > 0 && (
+                    <div className="uni-BodyHeader-sortBy">
+                      <span className="uni-Label">Sort by</span>
+                      <SortBy
+                        items={config.sorts}
+                        defaultRefinement={config.sorts[0].value}
+                      />
                     </div>
+                  )}
+
+                  <div>
+                    <Views view={view} setView={props.setView} />
                   </div>
                 </div>
-                <CurrentRefinements />
-              </header>
+              </div>
+              <CurrentRefinements />
+            </header>
 
-              <main className="uni-BodyContent">
-                <Banner />
-                <NoResultsHandler>
-                  <ProductList />
-                </NoResultsHandler>
-              </main>
-            </ScrollTo>
+            <main className="uni-BodyContent">
+              <Banner />
+              <NoResultsHandler>
+                <ProductList />
+              </NoResultsHandler>
+            </main>
           </div>
           <FiltersButton
             onClick={() => {


### PR DESCRIPTION
## Description

This scrolls to top on each page change, which avoids users to scroll back to top manually to scan items.

## Changes

I got rid of the `ScrollTo` component which didn't behave properly, and implemented our own `Pagination` component.