### PR TITLE
feat: allow escape to close filters

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -144,7 +144,12 @@ export function App({ config }) {
         if (event.keyCode === 27) {
           event.stopPropagation();
           event.preventDefault();
-          setIsOverlayShowing(false);
+
+          if (isFiltering) {
+            setIsFiltering(false);
+          } else {
+            setIsOverlayShowing(false);
+          }
         }
       } else if (!isOverlayShowing) {
         if (
@@ -163,7 +168,12 @@ export function App({ config }) {
     return () => {
       window.removeEventListener('keydown', onKeydown);
     };
-  }, [isOverlayShowing, setIsOverlayShowing, config.keyboardShortcuts]);
+  }, [
+    isOverlayShowing,
+    isFiltering,
+    setIsOverlayShowing,
+    config.keyboardShortcuts,
+  ]);
 
   return (
     <AppContext.Provider


### PR DESCRIPTION
When hitting <kbd>Esc</kbd> with the filters panel open, the whole search experience closed, which was confusing. We now support <kbd>Esc</kbd> to close the filters panel if open, and to close the search experience otherwise.