### PR TITLE
feat: add preconnect link to preview website

### DIFF
--- a/public/index.ejs
+++ b/public/index.ejs
@@ -8,6 +8,8 @@
     />
     <meta name="theme-color" content="#000" />
 
+    <link rel="preconnect" href="https://<%= appId %>-dsn.algolia.net" crossorigin />
+
     <link rel="shortcut icon" href="favicon.ico" />
     <link rel="manifest" href="manifest.json" />
     <link rel="stylesheet" href="reset.css" />

--- a/webpack/plugins/files.js
+++ b/webpack/plugins/files.js
@@ -1,16 +1,23 @@
+import 'ignore-styles';
+
 import CopyPlugin from 'copy-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+
+import config from '../../src/config/index';
 
 export default [
   new CopyPlugin([
     {
       from: '**/*',
-      ignore: ['index.html'],
+      ignore: ['index.ejs'],
       context: './public/',
     },
   ]),
   new HtmlWebpackPlugin({
     title: 'Unified InstantSearch E-commerce',
-    template: 'public/index.html',
+    template: 'public/index.ejs',
+    templateParameters: {
+      appId: config.appId,
+    },
   }),
 ];


### PR DESCRIPTION
This adds a `preconnect` link to the preview website, interpolated with the `appId` from the configuration.