### PR TITLE
fix(searchBox): autofocus input when modal opens

### DIFF
--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -23,6 +23,12 @@ export const SearchBox = (props) => {
     props.onReset();
   }
 
+  React.useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [inputRef]);
+
   return (
     <div className="ais-SearchBox">
       <form
@@ -102,7 +108,6 @@ export const SearchBox = (props) => {
             autoCapitalize="off"
             spellCheck={false}
             maxLength={512}
-            autoFocus
             placeholder={props.translations.placeholder}
             value={props.currentRefinement}
             onChange={props.onChange}


### PR DESCRIPTION
Since we switched from React to Preact, the app lost the "autofocus" feature on the input when the modal opens.

This happens because [Preact follows the HTML spec](https://github.com/preactjs/preact/issues/1255#issuecomment-439714572) of triggering the autofocus on page load, and not when the component mounts. React is more aggressive about this behavior.

This therefore gets rid of the `autoFocus` prop which is ignored here, and focuses the input with an effect.

Closes #119.