### PR TITLE
feat(mobile): display current refinements in filters panel

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -579,7 +579,7 @@
   background: rgba(255, 255, 255, 0.32);
   border-radius: 9999px;
   margin-left: 0.5rem;
-  min-width: 24px;
+  min-width: 22px;
   padding: 2px 6px;
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -577,7 +577,7 @@
 
 .uni-FiltersButton-Count {
   background: rgba(255, 255, 255, 0.32);
-  border-radius: 10px;
+  border-radius: 9999px;
   margin-left: 0.5rem;
   min-width: 24px;
   padding: 2px 6px;

--- a/src/App.scss
+++ b/src/App.scss
@@ -560,9 +560,9 @@
   height: 40px;
   justify-content: center;
   left: 50%;
+  min-width: 112px;
   position: fixed;
   transform: translateX(-50%);
-  width: 112px;
   z-index: 3;
   @media (--algolia-theme-breakpoint-sm-max) {
     bottom: 2rem;
@@ -573,6 +573,14 @@
   height: 14px;
   margin-right: 8px;
   width: 16px;
+}
+
+.uni-FiltersButton-Count {
+  background: rgba(255, 255, 255, 0.32);
+  border-radius: 10px;
+  margin-left: 0.5rem;
+  min-width: 24px;
+  padding: 2px 6px;
 }
 
 /* Container & Overlay */

--- a/src/components/CurrentRefinements.js
+++ b/src/components/CurrentRefinements.js
@@ -82,11 +82,17 @@ function getRefinement(refinement, config) {
 
 export const CurrentRefinements = connectCurrentRefinements(
   function CurrentRefinements({ items, refine }) {
-    const { config } = useAppContext();
+    const { config, setSearchContext } = useAppContext();
 
     const refinements = items.reduce((acc, current) => {
       return [...acc, ...getRefinement(current, config)];
     }, []);
+
+    React.useEffect(() => {
+      setSearchContext({
+        refinementCount: refinements.length,
+      });
+    }, [setSearchContext, refinements.length]);
 
     if (refinements.length === 0) {
       return null;

--- a/src/components/CurrentRefinements.scss
+++ b/src/components/CurrentRefinements.scss
@@ -1,7 +1,7 @@
 .ais-CurrentRefinements {
   padding-top: 1rem;
-  @media (--algolia-theme-breakpoint-sm-max) {
-    padding-top: 0.5rem;
+  @media (--algolia-theme-breakpoint-md-max) {
+    padding: 0 0 1rem;
   }
 }
 
@@ -26,11 +26,17 @@
 
 .ais-CurrentRefinements-label {
   padding: 4px 4px 4px 8px;
+  @media (--algolia-theme-breakpoint-md-max) {
+    padding: 0.5rem;
+  }
 }
 
 .ais-CurrentRefinements-categoryLabel {
   font-weight: bold;
   padding: 4px 6px 4px 0;
+  @media (--algolia-theme-breakpoint-md-max) {
+    padding: 0.5rem 0.5rem 0.5rem 0;
+  }
 }
 
 .ais-CurrentRefinements-delete {
@@ -41,4 +47,7 @@
   cursor: pointer;
   height: 100%;
   padding: 0 6px;
+  @media (--algolia-theme-breakpoint-md-max) {
+    padding: 0 0.5rem;
+  }
 }

--- a/src/components/FiltersButton.js
+++ b/src/components/FiltersButton.js
@@ -1,8 +1,11 @@
 import React from 'react';
 
 import { FilterIcon } from './FilterIcon';
+import { useSearchContext } from '../hooks';
 
 export function FiltersButton({ onClick }) {
+  const { refinementCount } = useSearchContext();
+
   return (
     <button
       data-layout="mobile"
@@ -11,6 +14,9 @@ export function FiltersButton({ onClick }) {
     >
       <FilterIcon />
       Filters
+      {refinementCount > 0 && (
+        <span className="uni-FiltersButton-Count">{refinementCount}</span>
+      )}
     </button>
   );
 }

--- a/src/components/Panel.scss
+++ b/src/components/Panel.scss
@@ -20,7 +20,10 @@
 }
 
 .ais-Panel-body {
-  margin-top: 1rem;
+  padding-top: 1rem;
+  @media (--algolia-theme-breakpoint-md-max) {
+    padding: 1rem 0;
+  }
 }
 
 .ais-Panel-noRefinement {

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -17,7 +17,7 @@ import { SeeResultsButton } from './SeeResultsButton';
 import { ResetButton } from './ResetButton';
 
 export function Search(props) {
-  const { config, view, searchParameters } = useAppContext();
+  const { config, view, searchParameters, isMobile } = useAppContext();
   const { isSearchStalled } = useSearchContext();
 
   const filtersAnchor = React.useRef();
@@ -79,6 +79,7 @@ export function Search(props) {
                     Close
                   </button>
                 </header>
+                {isMobile && <CurrentRefinements />}
                 <Refinements />
               </div>
               <footer className="uni-Refinements-footer" data-layout="mobile">
@@ -119,7 +120,7 @@ export function Search(props) {
                   </div>
                 </div>
               </div>
-              <CurrentRefinements />
+              {!isMobile && <CurrentRefinements />}
             </header>
 
             <main className="uni-BodyContent">


### PR DESCRIPTION
## Description

This PR changes the following on mobile:

- Move the current refinements in the filters panel
- Display the filters count in the filters button. This gives a clue to users about why only some search results appear.

## Preview

![image](https://user-images.githubusercontent.com/6137112/81546071-1f618780-937a-11ea-98f3-f6ee1cb7f9ba.png)

![image](https://user-images.githubusercontent.com/6137112/81546242-5f286f00-937a-11ea-87e2-3ec647de556f.png)

