### PR TITLE
chore(webpack): support local network development

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "start": "webpack-dashboard -- webpack-dev-server --open --config webpack/dev.babel.js",
+    "start": "webpack-dashboard -- webpack-dev-server --config webpack/dev.babel.js",
     "export": "webpack --config webpack/build.babel.js",
     "preview": "webpack --config webpack/preview.babel.js",
     "lint": "run-p -c lint:*",

--- a/webpack/dev.babel.js
+++ b/webpack/dev.babel.js
@@ -12,6 +12,8 @@ export default merge(base, {
     contentBase: './public',
     hot: true,
     port: 3000,
+    host: '0.0.0.0',
+    disableHostCheck: true,
   },
   plugins: [...files, new DashboardPlugin()],
   module: merge.smart(


### PR DESCRIPTION
This exposes the app to `0.0.0.0` in dev to be able to try the app on mobile on your local network.

I removed the `open` config because (1) it opens it on `0.0.0.0:3000` which displays a "Not secure" message and (2) I find it annoying that it messes up my tabs and virtual desktops.