### PR TITLE
ci: set Git identity before committing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# [0.1.0-beta.1](https://github.com/algolia/ecomm-unified/compare/v0.1.0-beta.0...v0.1.0-beta.1) (2020-05-11)
+
+
+### Bug Fixes
+
+* **mobile:** adjust mobile filtering design ([#112](https://github.com/algolia/ecomm-unified/issues/112)) ([62f5a62](https://github.com/algolia/ecomm-unified/commit/62f5a62f81771f0f9d0dae426fcbdf44aa0b0693))
+* **searchBox:** autofocus input when modal opens ([#121](https://github.com/algolia/ecomm-unified/issues/121)) ([09f1856](https://github.com/algolia/ecomm-unified/commit/09f18568f4da081453cf9334990235a82dfb9000))
+* fix grid view for no results page ([#105](https://github.com/algolia/ecomm-unified/issues/105)) ([6797bae](https://github.com/algolia/ecomm-unified/commit/6797bae212616b88374fc3927411f33181545062))
+* fix input completion offset ([#106](https://github.com/algolia/ecomm-unified/issues/106)) ([19e8b98](https://github.com/algolia/ecomm-unified/commit/19e8b98683b334827938e70cb0824a1d5f62fe18))
+* update "currency" casing ([f1038e6](https://github.com/algolia/ecomm-unified/commit/f1038e6760d1acc36f2cf0fd4cbad68570f58f3c))
+* **hits:** increase font weight ([3954fef](https://github.com/algolia/ecomm-unified/commit/3954fefac906a0d643a5a06b5fceff9a8f1a361d))
+* **sortBy:** align arrow ([981a65a](https://github.com/algolia/ecomm-unified/commit/981a65aab820a79ba6b9d4627d8e1f15ea6c096b))
+
+
+### Features
+
+* **mobile:** display current refinements in filters panel ([#123](https://github.com/algolia/ecomm-unified/issues/123)) ([017c572](https://github.com/algolia/ecomm-unified/commit/017c5722e55b258b18cdc79220ec93d5db59a56e))
+* **qs:** display bubbles on desktop ([#116](https://github.com/algolia/ecomm-unified/issues/116)) ([7c6a5e7](https://github.com/algolia/ecomm-unified/commit/7c6a5e71b46eebe52c7701fe0b525a93396f4864))
+* add preconnect link to preview website ([#115](https://github.com/algolia/ecomm-unified/issues/115)) ([78c6dee](https://github.com/algolia/ecomm-unified/commit/78c6dee4d9f06fbbee155ae00993097d559f45b5))
+* allow escape to close filters ([#113](https://github.com/algolia/ecomm-unified/issues/113)) ([4088264](https://github.com/algolia/ecomm-unified/commit/4088264b9c040a674a2ecb80deef675add3e3409))
+* **pagination:** scroll to top on page change ([#111](https://github.com/algolia/ecomm-unified/issues/111)) ([638442c](https://github.com/algolia/ecomm-unified/commit/638442cc47b84615c4a3f9838fe13bc959ebe7d8))
+* add baseZIndex congifuration ([#107](https://github.com/algolia/ecomm-unified/issues/107)) ([559509e](https://github.com/algolia/ecomm-unified/commit/559509e2c815ba1c6a77bb40bd1bb230c7fb6171))
+
+
+
 # 0.1.0-beta.0 (2020-05-07)
 
 Initial release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unified-instantsearch-ecommerce",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {

--- a/ship.config.js
+++ b/ship.config.js
@@ -15,6 +15,10 @@ module.exports = {
       `export const version = '${version}';\n`
     );
   },
+  beforeCommitChanges: ({ exec }) => {
+    exec('git config user.email "shipjs@test.com"');
+    exec('git config user.name "shipjs"');
+  },
   buildCommand() {
     // We don't build the project before releasing.
     return 'echo "No build needed."';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const version = '0.1.0-beta.0';
+export const version = '0.1.0-beta.1';


### PR DESCRIPTION
It seems that CircleCI [can't commit](https://circleci.com/gh/algolia/unified-instantsearch-ecommerce/122) because it doesn't have an identity set up (despite the GitHub token).

This PR sets an identity before committing, using Ship.js' [` beforeCommitChanges`](https://community.algolia.com/shipjs/reference/all-config.html#beforecommitchanges) hook.

The solution was suggested by this CircleCI's support center post: https://support.circleci.com/hc/en-us/articles/360018860473-How-to-push-a-commit-back-to-the-same-repository-as-part-of-the-CircleCI-job