### PR TITLE
ci: use CircleCI's config to set Git identity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,10 @@ jobs:
       - save_cache: *save_yarn_cache
       - run:
           name: Try to Release
-          command: yarn release:trigger
+          command: |
+            git config --global user.email "bot@shipjs.com"
+            git config --global user.name "shipjs"
+            yarn release:trigger
 workflows:
   version: 2
   ci:

--- a/ship.config.js
+++ b/ship.config.js
@@ -15,10 +15,6 @@ module.exports = {
       `export const version = '${version}';\n`
     );
   },
-  beforeCommitChanges: ({ exec }) => {
-    exec('git config user.email "shipjs@test.com"');
-    exec('git config user.name "shipjs"');
-  },
   buildCommand() {
     // We don't build the project before releasing.
     return 'echo "No build needed."';


### PR DESCRIPTION
After discussing with @eunjae-lee it seems that [`beforeCommitChanges`](https://community.algolia.com/shipjs/reference/all-config.html#beforecommitchanges) is for `shipjs prepare`, not `shipjs trigger`. Therefore, we can't use it to set Git identity during the build.

This sets it up right before `shipjs trigger`.