### PR TITLE
fix(mobile): update filters panel design

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -242,7 +242,7 @@
 .uni-Refinements-scrollable {
   @media (--algolia-theme-breakpoint-md-max) {
     flex-grow: 1;
-    padding: 1rem 1.5rem;
+    padding: 1rem;
   }
 }
 
@@ -256,6 +256,19 @@
   margin-bottom: 1rem;
 }
 
+.uni-Refinements-closeButton {
+  background: none;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  margin-right: -0.5rem;
+  padding: 0.5rem;
+  svg {
+    height: auto;
+    width: 20px;
+  }
+}
+
 .uni-Refinements-button {
   background-color: #dddcdc;
   border: 0;
@@ -263,6 +276,7 @@
   color: var(--algolia-theme-color-secondary);
   cursor: pointer;
   display: flex;
+  flex: 1;
   flex-shrink: 0;
   font-size: 0.75rem;
   font-weight: bold;
@@ -274,21 +288,19 @@
 .uni-Refinements-resultButton {
   background-color: var(--algolia-theme-color-primary);
   color: #fff;
-  margin-left: 1rem;
+  margin-left: 0.5rem;
 }
 
 .uni-Refinements-footer {
   background-color: #fff;
   border-top: 1px solid #ebecf3;
+  box-shadow: 0 0 4px rgba(150, 150, 150, 0.24);
   display: flex;
   flex-grow: 0;
   flex-shrink: 0;
-  padding: 1rem 1.5rem;
+  padding: 0.5rem;
   width: 100%;
   z-index: 2;
-  .uni-Refinements-button {
-    flex-grow: 1;
-  }
 }
 
 /* Containers */

--- a/src/components/Panel.scss
+++ b/src/components/Panel.scss
@@ -22,7 +22,8 @@
 .ais-Panel-body {
   padding-top: 1rem;
   @media (--algolia-theme-breakpoint-md-max) {
-    padding: 1rem 0;
+    padding-bottom: 1rem;
+    padding-top: 0;
   }
 }
 

--- a/src/components/ResetButton.js
+++ b/src/components/ResetButton.js
@@ -13,7 +13,7 @@ export const ResetButton = connectCurrentRefinements(function ResetButton(
       }}
       disabled={props.items.length === 0}
     >
-      Reset filters
+      Clear all
     </button>
   );
 });

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -74,9 +74,10 @@ export function Search(props) {
                     onClick={() => {
                       props.setIsFiltering(false);
                     }}
-                    className="uni-Refinements-button"
+                    className="uni-Refinements-closeButton"
+                    title="Close filters"
                   >
-                    Close
+                    <CloseIcon />
                   </button>
                 </header>
                 {isMobile && <CurrentRefinements />}


### PR DESCRIPTION
## Description

This brings the mobile filters panel design closer to what you would expect on a native app:

- Use a cross to close the panel
- Fix spacing (more compact globally, except touchable zones)
- Add shadow to refinement footer
- Rename "Reset filters" to "Clear all"

## Preview

![image](https://user-images.githubusercontent.com/6137112/81670084-623d6100-9447-11ea-8ddb-713897c61b42.png)
