### PR TITLE
feat: reuse config index name as default sort option

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -22,6 +22,14 @@ export function Search(props) {
 
   const filtersAnchor = React.useRef();
 
+  const defaultSort = [
+    {
+      label: 'Featured',
+      value: config.index.indexName,
+    },
+  ];
+  const sorts = defaultSort.concat(config.sorts);
+
   React.useEffect(() => {
     if (filtersAnchor.current && props.isFiltering) {
       filtersAnchor.current.scrollTop = 0;
@@ -106,12 +114,12 @@ export function Search(props) {
                 </div>
 
                 <div className="uni-BodyHeader-extraOptions">
-                  {config.sorts?.length > 0 && (
+                  {sorts?.length > 1 && (
                     <div className="uni-BodyHeader-sortBy">
                       <span className="uni-Label">Sort by</span>
                       <SortBy
-                        items={config.sorts}
-                        defaultRefinement={config.sorts[0].value}
+                        items={sorts}
+                        defaultRefinement={sorts[0].value}
                       />
                     </div>
                   )}

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -114,7 +114,7 @@ export function Search(props) {
                 </div>
 
                 <div className="uni-BodyHeader-extraOptions">
-                  {sorts?.length > 1 && (
+                  {sorts.length > 1 && (
                     <div className="uni-BodyHeader-sortBy">
                       <span className="uni-Label">Sort by</span>
                       <SortBy

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -27,10 +27,6 @@ const config = {
   googleAnalytics: false,
   sorts: [
     {
-      label: 'Featured',
-      value: 'instant_search',
-    },
-    {
       label: 'Price ascending',
       value: 'instant_search_price_asc',
     },


### PR DESCRIPTION
Currently, we're repeating the default index name twice in the config file: under `index.indexName` and under `sorts` as the first (default) sort-by option. We can remove this and instead reuse `index.indexName` within the `Search` component.

Note that I didn't keep the default label in the configuration to avoid making it more complex than it needs to be. In case users need to change it (which is possible but probably won't happen that much), they can search it through the project and change it without much trouble.

I've also changed the condition for displaying the sorts (more than one vs. more than none) because we don't need to show the widget if we only have the default sorting.