### PR TITLE
feat: throw when `inputContainer` refers to an <input>

### DIFF
--- a/src/components/SearchButton.js
+++ b/src/components/SearchButton.js
@@ -8,6 +8,14 @@ import { getDomElement } from '../utils';
 export const SearchButton = ({ onClick }) => {
   const { config } = useAppContext();
 
+  const inputSelector = getDomElement(config.inputContainer);
+
+  if (inputSelector instanceof HTMLInputElement) {
+    throw new Error(
+      'The `inputContainer` option must refer to a container (e.g., <div>), not an <input>.'
+    );
+  }
+
   return ReactDOM.createPortal(
     <button
       type="button"
@@ -28,7 +36,7 @@ export const SearchButton = ({ onClick }) => {
         </kbd>
       )}
     </button>,
-    getDomElement(config.inputContainer)
+    inputSelector
   );
 };
 

--- a/src/components/SearchButton.js
+++ b/src/components/SearchButton.js
@@ -8,9 +8,9 @@ import { getDomElement } from '../utils';
 export const SearchButton = ({ onClick }) => {
   const { config } = useAppContext();
 
-  const inputSelector = getDomElement(config.inputContainer);
+  const inputContainer = getDomElement(config.inputContainer);
 
-  if (inputSelector instanceof HTMLInputElement) {
+  if (inputContainer instanceof HTMLInputElement) {
     throw new Error(
       'The `inputContainer` option must refer to a container (e.g., <div>), not an <input>.'
     );
@@ -36,7 +36,7 @@ export const SearchButton = ({ onClick }) => {
         </kbd>
       )}
     </button>,
-    inputSelector
+    inputContainer
   );
 };
 


### PR DESCRIPTION
We generate the search box for users, but it's likely that they will try to integrate Unified in a website that already has one and will try to hook `inputContainer` to it. We mention it in the documentation, but we can't rely on this alone, as this is a likely error and it will make Unified fail from the very first try, causing a pretty bad experience.

We've seen that error during user testing, and it results in Preact throwing way too deep for the error to be understandable. This PR introduces a custom error that makes it clear what is happening and what steps to take from there.