### PR TITLE
feat: runtime validation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,5 +9,12 @@
         "ignoreFilenames": ["node_modules"]
       }
     ]
-  ]
+  ],
+  "env": {
+    "production": {
+      "plugins": [
+        "babel-plugin-strip-invariant"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@babel/runtime": "7.9.6",
     "babel-eslint": "10.1.0",
     "babel-loader": "8.1.0",
+    "babel-plugin-strip-invariant": "1.0.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "clean-webpack-plugin": "3.0.0",
     "copy-webpack-plugin": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "start": "webpack-dev-server --config webpack/dev.babel.js",
-    "export": "webpack --config webpack/build.babel.js",
-    "preview": "webpack --config webpack/preview.babel.js",
+    "start": "NODE_ENV=development webpack-dev-server --config webpack/dev.babel.js",
+    "export": "NODE_ENV=production webpack --config webpack/build.babel.js",
+    "preview": "NODE_ENV=production webpack --config webpack/preview.babel.js",
     "lint": "run-p -c lint:*",
     "lint:js": "eslint --ext .js .",
     "lint:css": "stylelint '**/*.(s)css'",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "algoliasearch": "4.1.0",
+    "invariant": "2.2.4",
     "node-sass": "4.13.1",
     "qs": "6.9.3",
     "react": "16.13.1",

--- a/src/components/CurrentRefinements.js
+++ b/src/components/CurrentRefinements.js
@@ -73,9 +73,7 @@ function getRefinement(refinement, config) {
     }
 
     default: {
-      throw new Error(
-        `The refinement type "${refinementConfig.type}" is not supported.`
-      );
+      return null;
     }
   }
 }

--- a/src/components/Refinements.js
+++ b/src/components/Refinements.js
@@ -56,7 +56,7 @@ function RefinementWidget({ type, ...props }) {
       );
 
     default:
-      throw new Error(`The refinement type "${type}" is not supported.`);
+      return null;
   }
 }
 

--- a/src/components/SearchButton.js
+++ b/src/components/SearchButton.js
@@ -8,14 +8,6 @@ import { getDomElement } from '../utils';
 export const SearchButton = ({ onClick }) => {
   const { config } = useAppContext();
 
-  const inputContainer = getDomElement(config.inputContainer);
-
-  if (inputContainer instanceof HTMLInputElement) {
-    throw new Error(
-      'The `inputContainer` option must refer to a container (e.g., <div>), not an <input>.'
-    );
-  }
-
   return ReactDOM.createPortal(
     <button
       type="button"
@@ -36,7 +28,7 @@ export const SearchButton = ({ onClick }) => {
         </kbd>
       )}
     </button>,
-    inputContainer
+    getDomElement(config.inputContainer)
   );
 };
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -37,7 +37,7 @@ const config = {
   ],
   refinements: [
     {
-      type: 'hierarchicall',
+      type: 'hierarchical',
       header: 'Categories',
       label: 'Category',
       options: {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -37,7 +37,7 @@ const config = {
   ],
   refinements: [
     {
-      type: 'hierarchical',
+      type: 'hierarchicall',
       header: 'Categories',
       label: 'Category',
       options: {

--- a/src/config/rules.js
+++ b/src/config/rules.js
@@ -17,7 +17,7 @@ const rules = {
 
       return response;
     },
-    errorMessage(_, context) {
+    errorMessage(context) {
       if (!context?.isElement) {
         return 'The `inputContainer` option must refer to a valid HTML element.';
       }
@@ -44,7 +44,7 @@ const rules = {
 
       return response;
     },
-    errorMessage(_, context) {
+    errorMessage(context) {
       return `The refinement type "${context?.unknownType?.type}" is not supported.`;
     },
   },

--- a/src/config/rules.js
+++ b/src/config/rules.js
@@ -1,0 +1,53 @@
+import { getDomElement } from '../utils';
+
+const rules = {
+  inputContainer: {
+    validate(input) {
+      const inputContainer = getDomElement(input);
+      const isElement = inputContainer instanceof HTMLElement;
+      const isInputElement = inputContainer instanceof HTMLInputElement;
+
+      const response = {
+        valid: isElement && !isInputElement,
+        context: {
+          isElement,
+          isInputElement,
+        },
+      };
+
+      return response;
+    },
+    errorMessage(_, context) {
+      if (!context?.isElement) {
+        return 'The `inputContainer` option must refer to a valid HTML element.';
+      }
+      if (context?.isInputElement) {
+        return 'The `inputContainer` option must refer to a container (e.g., <div>), not an <input>.';
+      }
+
+      return '';
+    },
+  },
+  refinements: {
+    validate(input) {
+      const acceptedTypes = ['hierarchical', 'category', 'list', 'slider'];
+      const unknownType = input.find(
+        ({ type }) => !acceptedTypes.includes(type)
+      );
+
+      const response = {
+        valid: !unknownType,
+        context: {
+          unknownType,
+        },
+      };
+
+      return response;
+    },
+    errorMessage(_, context) {
+      return `The refinement type "${context?.unknownType?.type}" is not supported.`;
+    },
+  },
+};
+
+export default rules;

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,11 @@ import './theme.scss';
 import './App.scss';
 
 import config from './config';
+import rules from './config/rules';
 import { App } from './App';
-import { getDomElement } from './utils';
+import { getDomElement, validateConfig } from './utils';
+
+validateConfig(config, rules);
 
 ReactDOM.render(
   <Router>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,5 @@
+import invariant from 'invariant';
+
 export function parseAttribute({
   highlightPreTag,
   highlightPostTag,
@@ -54,4 +56,17 @@ export function getDomElement(value) {
   const isSelectorString = typeof value === 'string';
 
   return isSelectorString ? document.querySelector(value) : value;
+}
+
+export function validateConfig(config, rules) {
+  Object.keys(config).forEach((optionName) => {
+    const input = config[optionName];
+    const rule = rules[optionName];
+
+    if (rule) {
+      const { valid, context } = rule.validate(input);
+
+      invariant(valid, rule.errorMessage(input, context));
+    }
+  });
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -66,7 +66,7 @@ export function validateConfig(config, rules) {
     if (rule) {
       const { valid, context } = rule.validate(input);
 
-      invariant(valid, rule.errorMessage(input, context));
+      invariant(valid, rule.errorMessage({ ...context, input }));
     }
   });
 }

--- a/webpack/base.babel.js
+++ b/webpack/base.babel.js
@@ -4,6 +4,7 @@ import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import config from './config';
 
 export default {
+  mode: process.env.NODE_ENV,
   entry: './src/index.js',
   output: {
     filename: `${config.filename}.js`,

--- a/webpack/build.babel.js
+++ b/webpack/build.babel.js
@@ -11,7 +11,6 @@ import scss from './loaders/scss';
 import config from './config';
 
 export default merge(base, {
-  mode: 'production',
   output: {
     path: path.resolve('./export'),
   },

--- a/webpack/dev.babel.js
+++ b/webpack/dev.babel.js
@@ -5,7 +5,6 @@ import scss from './loaders/scss';
 import files from './plugins/files';
 
 export default merge(base, {
-  mode: 'development',
   devtool: 'inline-source-map',
   devServer: {
     contentBase: './public',

--- a/webpack/preview.babel.js
+++ b/webpack/preview.babel.js
@@ -5,6 +5,7 @@ import build from './build.babel';
 import files from './plugins/files';
 
 export default merge(build, {
+  mode: 'production',
   output: {
     path: path.resolve('./preview'),
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1906,6 +1906,11 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-strip-invariant@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-strip-invariant/-/babel-plugin-strip-invariant-1.0.0.tgz#09d1046a0bf818f558535a4d7a87cbc4a6136d11"
+  integrity sha512-ZQcVDBlxcpKiayFfGq+YQs4JdR6E8k78JCFXaMpu33DL5pddrpAsYxv1Qm5Is1daT5OUdoNr7yuuTaRcSFn7GQ==
+
 babel-plugin-transform-react-remove-prop-types@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5094,9 +5094,10 @@ interpret@1.2.0, interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@^2.2.2, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
In #138 we brought up the idea of [adding a runtime validation step](https://github.com/algolia/unified-instantsearch-ecommerce/pull/138#issuecomment-662900321) to verify invariants. This PR introduces one using [`invariant`](https://github.com/zertosh/invariant), a mirror of what Facebook uses within React.

_**N.B.:** [The React invariant module has changed since then](https://reactjs.org/blog/2016/07/11/introducing-reacts-error-code-system.html), they also provide links to an error decoder on their site which returns the actual invariant message. I think we're okay with the generic message for now since we don't have that many invariants. We can look into it later on if we think this is an actual problem._

## Summary

Instead of throwing within components when a configuration option isn't properly set, we now check them all right before running the application, via a `validateConfig` function. This function takes the configuration object and a set of rules. The rules are grouped within an object which keys are the top-level name of the option, and which value is an object that implements two methods: `validate` and `errorMessage`.

The `validate` method takes the value of the option, method performs an assertion, and returns an object that contains two properties: `valid`, which is the result of the assertion, and `context`, for returning extra information about the assertion (useful for error messages).

The `errorMessage` method takes a context, and returns an error message.

The `validateConfig` function iterates through the configuration and checks each against their rule, and throws using `invariant` when there's a violation.

Here's an example of what it looks like in development mode, when passing an invalid `type` to one of the `refinements`:

![Capture d’écran 2020-07-24 à 14 01 15](https://user-images.githubusercontent.com/5370675/88391294-311fcc00-cdba-11ea-9e2b-04c12b68f758.png)

In production, we want to trim away as many bytes as we can, so we strip away these specific messages and return a generic error message instead.

![Capture d’écran 2020-07-24 à 14 02 02](https://user-images.githubusercontent.com/5370675/88391405-6af0d280-cdba-11ea-88b1-c6a34f033a76.png)

## Next steps

Once we have a more broken down documentation with short links (as brought up in #139) we can add links to the development errors for even better DX.