### PR TITLE
fix: define `window` to avoid breakage when using it in the config file

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,9 @@
 /* eslint-disable import/no-commonjs */
 
+// When the configuration file refers to `window`, we need to shim it so it
+// doesn't break when processed with Node during the build step.
+window = global;
+
 require('ignore-styles');
 const postcssPresetEnv = require('postcss-preset-env');
 const postcssInjectCssVariables = require('postcss-inject-css-variables');


### PR DESCRIPTION
When a user uses `window` in the config file outside of a function, it will break the `export` process because the `postcss.config.js` file imports the config file to get the data under `styles`. Because `window` doesn't exist in Node, it throws.

This PR fixes the issue by defining `window` and setting it to `global`. We don't care that `window` doesn't exist in that case because we don't want to get data from it in this context. Styles need to be defined statically for now, because we need them to write the stylesheet.