### PR TITLE
fix(settings): remove unsupported `searchable` hierarchical option

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -112,7 +112,6 @@ export const refinements = [
         'hierarchicalCategories.lvl1',
       ],
       limit: 6,
-      searchable: true,
       showMore: true,
     },
   },


### PR DESCRIPTION
The `searchable` option is not supported by [`HierarchicalMenu`](https://www.algolia.com/doc/api-reference/widgets/hierarchical-menu/react/).