### PR TITLE
fix: authorize global assignment of `window` in PostCSS file

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-commonjs */
+/* eslint-disable import/no-commonjs, no-global-assign */
 
 // When the configuration file refers to `window`, we need to shim it so it
 // doesn't break when processed with Node during the build step.


### PR DESCRIPTION
When the configuration file refers to `window`, we need to shim it so it doesn't break when processed with Node during the build step. This is a violation of ESLint rules because we shall not assign to native objects or read-only global variables, but it's okay in our case.

## What's next

Depending on what browsers we decide to support in the future, we may want to leverage [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) instead. We currently cannot since we support IE11, but since Microsoft has decided to drop support, and depending on InstantSearch decisions regarding browser support, we may want to follow that as well.