### PR TITLE
chore(release): fix release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           command: |
             git config --global user.email "bot@shipjs.com"
             git config --global user.name "shipjs"
-            yarn release:trigger
+            yarn shipjs trigger
 workflows:
   version: 2
   ci:

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "postcss-preset-env": "6.7.0",
     "prettier": "2.0.4",
     "sass-loader": "8.0.2",
-    "shipjs": "0.18.4",
+    "shipjs": "0.21.0",
     "style-loader": "1.2.1",
     "stylelint": "13.3.2",
     "stylelint-a11y": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "lint": "run-p -c lint:*",
     "lint:js": "eslint --ext .js .",
     "lint:css": "stylelint '**/*.(s)css'",
-    "release:prepare": "shipjs prepare",
-    "release:trigger": "shipjs trigger"
+    "release": "shipjs prepare"
   },
   "dependencies": {
     "algoliasearch": "4.1.0",

--- a/ship.config.js
+++ b/ship.config.js
@@ -4,11 +4,6 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = {
-  mergeStrategy: {
-    toReleaseBranch: {
-      next: 'master',
-    },
-  },
   versionUpdated({ version, dir }) {
     fs.writeFileSync(
       path.resolve(dir, 'src', 'version.js'),
@@ -17,10 +12,9 @@ module.exports = {
   },
   buildCommand() {
     // We don't build the project before releasing.
-    return 'echo "No build needed."';
+    return null;
   },
   publishCommand() {
-    // We don't publish to npm.
-    return 'echo "No publish needed."';
+    return 'git checkout master && git rebase next';
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8823,10 +8823,10 @@ shelljs@0.8.4:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shipjs-lib@0.18.4:
-  version "0.18.4"
-  resolved "https://registry.yarnpkg.com/shipjs-lib/-/shipjs-lib-0.18.4.tgz#cd509f1d3a60b4acc4b6c1a335f19f81c6253eb5"
-  integrity sha512-syu025fGRRTfLTQPZHhWoKsTaeHQBzoOeUUFuWw2RnGVG7SjjE7JQd22gGkT622KhGbvHefBaNwUeC05WxoGOA==
+shipjs-lib@0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/shipjs-lib/-/shipjs-lib-0.21.0.tgz#a4570c44903d28fb80e548c1907f8282264de190"
+  integrity sha512-TKMtbl9rDYs7kxK9QBM0cGXQYCRCmNF1ACLocsqwll7OwOKnWm/GeubeWi/tSEcj5E2jFUGS2ZLXKZ1jRW+SZw==
   dependencies:
     deepmerge "^4.2.2"
     dotenv "^8.1.0"
@@ -8834,10 +8834,10 @@ shipjs-lib@0.18.4:
     semver "6.3.0"
     shelljs "0.8.4"
 
-shipjs@0.18.4:
-  version "0.18.4"
-  resolved "https://registry.yarnpkg.com/shipjs/-/shipjs-0.18.4.tgz#d9844a82781bc79b693afddda1ebe1457747546d"
-  integrity sha512-By6Q35LdReJLRsQnV1Ackxlgpn3NVDfTIsNfxMxHlBnFSBjhTw5JnxAaWHIROldwbI5bd51rR8Upm0GZwQQcJQ==
+shipjs@0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/shipjs/-/shipjs-0.21.0.tgz#28c76dec11502d1031b31921fa538cd66aeeee1b"
+  integrity sha512-ovrn6JhrMA9MV/xWGs69U7wv36cw/bWGL0pio9OodglC97HpZaRiO54vR9DPU6o/biqAvGMDglqFzhCA9On63Q==
   dependencies:
     "@babel/runtime" "^7.6.3"
     "@octokit/rest" "^17.0.0"
@@ -8858,7 +8858,7 @@ shipjs@0.18.4:
     prettier "^2.0.0"
     serialize-javascript "^3.0.0"
     shell-quote "^1.7.2"
-    shipjs-lib "0.18.4"
+    shipjs-lib "0.21.0"
     temp-write "4.0.0"
     tempfile "^3.0.0"
 


### PR DESCRIPTION
This updates our broken releasing process. The new flow is:

- Trigger `yarn release`
- Opens a PR via Ship.js targeting the `next` branch
- We squash merge the PR
- Ship.js prepares the release and runs the command `git checkout master && git rebase next` to get all the commits from `next` to `master`