### PR TITLE
chore: add google tag manager code on live demo

### DIFF
--- a/public/index.ejs
+++ b/public/index.ejs
@@ -493,5 +493,16 @@
     </footer>
 
     <script src="https://polyfill.io/v3/polyfill.min.js?features=default,Array.prototype.find,Array.prototype.includes,Promise,Object.assign,Object.entries,Object.values,IntersectionObserver"></script>
+    <% if (netlify) { %>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-32446386-48"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-32446386-48');
+    </script>
+    <% } %>
   </body>
 </html>

--- a/webpack/plugins/files.js
+++ b/webpack/plugins/files.js
@@ -22,6 +22,7 @@ export default [
     template: 'public/index.ejs',
     templateParameters: {
       appId: config.appId,
+      netlify: process.env.NETLIFY || false,
     },
   }),
 ];


### PR DESCRIPTION
This PR enables tracking on the Netlify-hosted live demo, using Google Tag Manager.