### PR TITLE
fix: include react-router in transpilation to es5

### DIFF
--- a/webpack/base.babel.js
+++ b/webpack/base.babel.js
@@ -14,8 +14,13 @@ export default {
     rules: [
       {
         test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: ['babel-loader'],
+        exclude: /node_modules\/(?!react-router)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env'],
+          },
+        },
       },
     ],
   },


### PR DESCRIPTION
This PR removes `react-router` and `react-router-dom` from the transpilation exclusion list, as in they are exported in ES6, which breaks compatibility with IE11.